### PR TITLE
Fix generator Prettier formatting and Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,15 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install dependencies
-RUN npm ci
+# Install dependencies (ignore scripts to avoid premature build)
+# The prepare script runs npm build, but tsconfig.json isn't copied yet
+RUN npm ci --ignore-scripts
 
 # Copy source files
 COPY tsconfig.json ./
 COPY src/ ./src/
 
-# Build TypeScript
+# Build TypeScript (now that all source files are present)
 RUN npm run build
 
 # Prune dev dependencies


### PR DESCRIPTION
## Summary
- Add Prettier integration to `scripts/generate.ts` to automatically format generated TypeScript files
- Fix Docker build by using `--ignore-scripts` during `npm ci` to prevent premature build before source files are copied

## Changes
1. **Generator Prettier Integration**:
   - Added `prettier` import and configuration
   - Created `formatCode()` helper function
   - Created `writeFormattedFile()` to format before writing
   - All generated files now pass Prettier checks automatically

2. **Docker Build Fix**:
   - Added `--ignore-scripts` flag to `npm ci` in Dockerfile
   - The `prepare` script was running `npm run build` before `tsconfig.json` was copied
   - Now build runs explicitly after all source files are present

## Fixes
- Fixes #6: Docker build fails due to tsc not finding tsconfig.json
- Addresses feedback: generators should output lint-compatible code rather than requiring manual formatting

## Test plan
- [ ] Verify `npm run generate` produces Prettier-formatted files
- [ ] Verify `npm run format:check` passes after generation
- [ ] Verify Docker build succeeds
- [ ] Verify CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)