### PR TITLE
fix(docs): standardize naming convention to use example- prefix

### DIFF
--- a/docs/getting-started/claude-code.md
+++ b/docs/getting-started/claude-code.md
@@ -130,7 +130,7 @@ Then use a simpler config:
 
 ```bash
 # Start Claude Code in your Terraform project
-cd my-terraform-project
+cd example-terraform-project
 claude-code
 
 # Ask Claude to help with F5XC resources

--- a/docs/integrations/f5xcctl.md
+++ b/docs/integrations/f5xcctl.md
@@ -69,16 +69,16 @@ export VOLT_API_URL="https://your-tenant.console.ves.volterra.io/api"
 
 ```bash
 # YAML output (default)
-f5xcctl get http_loadbalancer my-app -n production -o yaml
+f5xcctl get http_loadbalancer example-app -n production -o yaml
 
 # JSON output
-f5xcctl get http_loadbalancer my-app -n production -o json
+f5xcctl get http_loadbalancer example-app -n production -o json
 
 # Table output
 f5xcctl get http_loadbalancers -n production -o table
 
 # Terraform output
-f5xcctl get http_loadbalancer my-app -n production -o terraform
+f5xcctl get http_loadbalancer example-app -n production -o terraform
 ```
 
 ## Workflow Examples
@@ -113,7 +113,7 @@ f5xcctl apply -f config.yaml --dry-run
 
 ```bash
 # Export to file
-f5xcctl get http_loadbalancer my-app -n production -o yaml > my-app.yaml
+f5xcctl get http_loadbalancer example-app -n production -o yaml > example-app.yaml
 
 # Export multiple resources
 f5xcctl get http_loadbalancers -n production -o yaml > all-lbs.yaml
@@ -144,10 +144,10 @@ f5xcctl get app_firewalls -n production
 
 ```bash
 # Detailed output
-f5xcctl get http_loadbalancer my-app -n production -o yaml
+f5xcctl get http_loadbalancer example-app -n production -o yaml
 
 # With status
-f5xcctl get http_loadbalancer my-app -n production --show-status
+f5xcctl get http_loadbalancer example-app -n production --show-status
 ```
 
 ### Apply Configuration
@@ -169,13 +169,13 @@ f5xcctl apply -f lb.yaml -f origin.yaml -f waf.yaml
 
 ```bash
 # Single resource
-f5xcctl delete http_loadbalancer my-app -n production
+f5xcctl delete http_loadbalancer example-app -n production
 
 # From file
 f5xcctl delete -f http-lb.yaml
 
 # Force delete
-f5xcctl delete http_loadbalancer my-app -n production --force
+f5xcctl delete http_loadbalancer example-app -n production --force
 ```
 
 ## Tips
@@ -206,7 +206,7 @@ f5xcctl get http_loadbalancers -n production -o json | jq '.items[].metadata.nam
 
 ```bash
 # Monitor status changes
-watch f5xcctl get http_loadbalancer my-app -n production --show-status
+watch f5xcctl get http_loadbalancer example-app -n production --show-status
 ```
 
 ## Troubleshooting

--- a/docs/integrations/terraform.md
+++ b/docs/integrations/terraform.md
@@ -72,7 +72,7 @@ variable "api_token" {
 
 ```hcl
 resource "volterra_http_loadbalancer" "example" {
-  name      = "my-app"
+  name      = "example-app"
   namespace = "production"
 
   domains = ["app.example.com"]
@@ -193,7 +193,7 @@ Ask Claude:
 Example output:
 
 ```bash
-terraform import volterra_http_loadbalancer.my_app production/my-app
+terraform import volterra_http_loadbalancer.example_app production/example-app
 terraform import volterra_http_loadbalancer.api production/api
 ```
 
@@ -206,7 +206,7 @@ Ask Claude:
 > ```yaml
 > kind: http_loadbalancer
 > metadata:
->   name: my-app
+>   name: example-app
 > spec:
 >   ...
 > ```"
@@ -219,7 +219,7 @@ Ask Claude:
 module "load_balancer" {
   source = "./modules/load-balancer"
 
-  name        = "my-app"
+  name        = "example-app"
   namespace   = "production"
   domains     = ["app.example.com"]
 
@@ -316,7 +316,7 @@ data "volterra_namespace" "production" {
 }
 
 data "volterra_http_loadbalancer" "existing" {
-  name      = "my-app"
+  name      = "example-app"
   namespace = data.volterra_namespace.production.name
 }
 ```
@@ -345,7 +345,7 @@ provider "volterra" {
 Import the existing resource:
 
 ```bash
-terraform import volterra_http_loadbalancer.app production/my-app
+terraform import volterra_http_loadbalancer.app production/example-app
 ```
 
 ## Next Steps

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -134,7 +134,7 @@ Once configured, try these example prompts:
 
 > "Create an origin pool pointing to 10.0.0.1:8080"
 
-> "Get the status of the 'my-app' load balancer"
+> "Get the status of the 'example-app' load balancer"
 
 ## Next Steps
 

--- a/docs/tools/app-firewall.md
+++ b/docs/tools/app-firewall.md
@@ -238,7 +238,7 @@ Reference the firewall in your HTTP Load Balancer:
 Or via Terraform:
 
 ```hcl
-resource "volterra_http_loadbalancer" "my_app" {
+resource "volterra_http_loadbalancer" "example_app" {
   # ... other config ...
 
   app_firewall {

--- a/docs/tools/aws-vpc-site.md
+++ b/docs/tools/aws-vpc-site.md
@@ -52,7 +52,7 @@ metadata:
 spec:
   aws_region: us-east-1
   aws_cred:
-    name: my-aws-creds
+    name: example-aws-creds
     namespace: system
   vpc:
     vpc_id: vpc-12345678
@@ -104,7 +104,7 @@ For internet-facing applications with outbound connectivity:
   "namespace": "system",
   "aws_region": "us-east-1",
   "aws_cred": {
-    "name": "my-aws-creds",
+    "name": "example-aws-creds",
     "namespace": "system"
   },
   "vpc": {

--- a/docs/tools/azure-vnet-site.md
+++ b/docs/tools/azure-vnet-site.md
@@ -53,12 +53,12 @@ metadata:
 spec:
   azure_region: eastus
   azure_cred:
-    name: my-azure-creds
+    name: example-azure-creds
     namespace: system
   vnet:
     existing_vnet:
-      resource_group: my-rg
-      vnet_name: my-vnet
+      resource_group: example-rg
+      vnet_name: example-vnet
   instance_type: Standard_D3_v2
   ingress_egress_gw:
     azure_certified_hw: azure-byol-voltmesh
@@ -83,8 +83,8 @@ resource "volterra_azure_vnet_site" "azure_east" {
 
   vnet {
     existing_vnet {
-      resource_group = "my-rg"
-      vnet_name      = "my-vnet"
+      resource_group = "example-rg"
+      vnet_name      = "example-vnet"
     }
   }
 

--- a/docs/tools/gcp-vpc-site.md
+++ b/docs/tools/gcp-vpc-site.md
@@ -53,11 +53,11 @@ metadata:
 spec:
   gcp_region: us-central1
   gcp_cred:
-    name: my-gcp-creds
+    name: example-gcp-creds
     namespace: system
   vpc_network:
     existing_network:
-      name: my-vpc
+      name: example-vpc
   instance_type: n1-standard-4
   ingress_egress_gw:
     gcp_certified_hw: gcp-byol-voltmesh
@@ -82,7 +82,7 @@ resource "volterra_gcp_vpc_site" "gcp_central" {
 
   vpc_network {
     existing_network {
-      name = "my-vpc"
+      name = "example-vpc"
     }
   }
 

--- a/docs/tools/http-loadbalancer.md
+++ b/docs/tools/http-loadbalancer.md
@@ -27,7 +27,7 @@ The HTTP Load Balancer is the primary resource for exposing applications through
 
 Ask Claude:
 
-> "Create an HTTP load balancer named 'my-app' in the 'production' namespace
+> "Create an HTTP load balancer named 'example-app' in the 'production' namespace
 > for domain 'app.example.com' with origin pool 'backend-pool'"
 
 ### f5xcctl Equivalent
@@ -37,7 +37,7 @@ f5xcctl apply -f - <<EOF
 apiVersion: config.volterra.io/v1
 kind: http_loadbalancer
 metadata:
-  name: my-app
+  name: example-app
   namespace: production
 spec:
   domains:
@@ -57,8 +57,8 @@ EOF
 ### Terraform Resource
 
 ```hcl
-resource "volterra_http_loadbalancer" "my_app" {
-  name      = "my-app"
+resource "volterra_http_loadbalancer" "example_app" {
+  name      = "example-app"
   namespace = "production"
 
   domains = ["app.example.com"]
@@ -85,7 +85,7 @@ resource "volterra_http_loadbalancer" "my_app" {
 
 ```json
 {
-  "name": "my-app",
+  "name": "example-app",
   "namespace": "production",
   "domains": ["app.example.com"],
   "http": {
@@ -106,7 +106,7 @@ resource "volterra_http_loadbalancer" "my_app" {
 
 ```json
 {
-  "name": "my-app",
+  "name": "example-app",
   "namespace": "production",
   "domains": ["app.example.com"],
   "https_auto_cert": {
@@ -126,12 +126,12 @@ resource "volterra_http_loadbalancer" "my_app" {
 
 ```json
 {
-  "name": "my-app",
+  "name": "example-app",
   "namespace": "production",
   "domains": ["app.example.com"],
   "app_firewall": {
     "namespace": "production",
-    "name": "my-waf-policy"
+    "name": "example-waf"
   },
   "default_route_pools": [{
     "pool": {
@@ -179,7 +179,7 @@ resource "volterra_http_loadbalancer" "my_app" {
         "network": "SITE_NETWORK_INSIDE",
         "site": {
           "namespace": "system",
-          "name": "my-site"
+          "name": "example-site"
         }
       }
     }]

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -97,7 +97,7 @@ Execute a discovered API tool.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `toolName` | string | Yes | The exact tool name to execute |
-| `pathParams` | object | No | Path parameters (e.g., `{ namespace: "default", name: "my-lb" }`) |
+| `pathParams` | object | No | Path parameters (e.g., `{ namespace: "default", name: "example-lb" }`) |
 | `queryParams` | object | No | Query parameters for the request |
 | `body` | object | No | Request body for POST/PUT/PATCH operations |
 

--- a/docs/tools/origin-pool.md
+++ b/docs/tools/origin-pool.md
@@ -101,7 +101,7 @@ resource "volterra_origin_pool" "backend" {
       "site_locator": {
         "site": {
           "namespace": "system",
-          "name": "my-site"
+          "name": "example-site"
         }
       }
     }
@@ -127,11 +127,11 @@ resource "volterra_origin_pool" "backend" {
 {
   "origin_servers": [{
     "k8s_service": {
-      "service_name": "my-service",
+      "service_name": "example-service",
       "site_locator": {
         "site": {
           "namespace": "system",
-          "name": "my-k8s-site"
+          "name": "example-k8s-site"
         }
       },
       "vk8s_networks": {}

--- a/docs/tools/rate-limiter.md
+++ b/docs/tools/rate-limiter.md
@@ -127,7 +127,7 @@ Reference the rate limiter in an HTTP Load Balancer:
 
 ```json
 {
-  "name": "my-app",
+  "name": "example-app",
   "rate_limiter": {
     "namespace": "production",
     "name": "api-limit"


### PR DESCRIPTION
## Summary
- Standardize all documentation examples to use `example-` prefix instead of `my-` prefix
- Aligns with the naming convention in `src/generator/transformers/normalize-examples.ts`
- Ensures consistency between generated tool descriptions and manually written documentation

## Changes
- Updated 12 documentation files across tools, integrations, quickstart, and getting-started
- Replaced patterns like `my-app`, `my-site`, `my-vpc`, `my-creds` with `example-app`, `example-site`, `example-vpc`, `example-creds`

## Files Modified
- `docs/tools/http-loadbalancer.md`
- `docs/tools/aws-vpc-site.md`
- `docs/tools/azure-vnet-site.md`
- `docs/tools/gcp-vpc-site.md`
- `docs/tools/origin-pool.md`
- `docs/tools/rate-limiter.md`
- `docs/tools/app-firewall.md`
- `docs/tools/index.md`
- `docs/integrations/f5xcctl.md`
- `docs/integrations/terraform.md`
- `docs/quickstart.md`
- `docs/getting-started/claude-code.md`

## Test plan
- [x] Verified no `my-` patterns remain in docs/ directory
- [x] Markdownlint validation passes
- [ ] Documentation builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)