### PR TITLE
fix(ci): add issues permission and NPM_TOKEN for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- Add `issues: write` permission to release workflow for semantic-release to create release notes
- Configure `NPM_TOKEN` repository secret for npm publishing

## Changes

- `.github/workflows/release.yml`: Added `issues: write` permission

## Root Cause

The Release workflow was failing with:
1. **403 Error**: "Resource not accessible by integration" - semantic-release couldn't create release issues
2. **EINVALIDNPMTOKEN**: No NPM_TOKEN secret was configured

## Test Plan

- [ ] PR CI checks pass
- [ ] After merge, Release workflow should succeed on next conventional commit

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)