### PR TITLE
fix(ci): add NODE_AUTH_TOKEN for npm authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   docker:
     name: Docker Build & Push


### PR DESCRIPTION
## Summary

Add `NODE_AUTH_TOKEN` environment variable for npm authentication in semantic-release.

## Problem

The `setup-node` action with `registry-url` creates an `.npmrc` file that expects `NODE_AUTH_TOKEN` for authentication. Semantic-release was only receiving `NPM_TOKEN`.

## Solution

Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` alongside the existing `NPM_TOKEN` variable in the Semantic Release step.

## Reference

Based on working pattern from: https://github.com/robinmordasiewicz/terraform-provider-f5xc/blob/main/.github/workflows/on-merge.yml

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)