### PR TITLE
fix: resolve CI and Security workflow issues (#18, #20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           tags: f5xc-api-mcp:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -103,8 +103,8 @@ jobs:
         uses: trufflesecurity/trufflehog@v3.90.0
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'push' && github.event.before || github.event.repository.default_branch }}
+          head: ${{ github.event_name == 'push' && github.event.after || 'HEAD' }}
           extra_args: --only-verified
 
   license-check:


### PR DESCRIPTION
## Summary
- Fix Trivy container scanner unable to find Docker image (Issue #18)
- Fix TruffleHog secret scan failing on push events (Issue #20)

## Changes

### Issue #18 - CI Trivy Scanner
**File**: `.github/workflows/ci.yml`

Added `load: true` to `docker/build-push-action` to make the built image available in the local Docker daemon for Trivy to scan.

```yaml
- name: Build Docker image
  uses: docker/build-push-action@v5
  with:
    context: .
    push: false
    load: true  # Added - loads image into local daemon
    tags: f5xc-api-mcp:${{ github.sha }}
```

### Issue #20 - TruffleHog Secret Scan
**File**: `.github/workflows/security.yml`

Changed TruffleHog base/head configuration to use `github.event.before` and `github.event.after` for push events, which provides the actual commit range being pushed.

```yaml
base: ${{ github.event_name == 'push' && github.event.before || github.event.repository.default_branch }}
head: ${{ github.event_name == 'push' && github.event.after || 'HEAD' }}
```

## Test plan
- [ ] CI workflow Docker Build job completes with Trivy scan
- [ ] Security workflow Secret Detection passes on push events
- [ ] PR checks still work correctly

Closes #18
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)