### PR TITLE
fix: add security-events permission for SARIF upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
   packages: write
   id-token: write
   issues: write
+  security-events: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- Adds `security-events: write` permission to Release workflow
- Required for Trivy SARIF upload via CodeQL action

## Problem
The Release workflow was failing at the "Upload Trivy scan results" step with:
```
Resource not accessible by integration
```

## Solution
Added missing `security-events: write` permission to workflow permissions block.

## Test plan
- [ ] Verify PR checks pass
- [ ] Verify Release workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)