### PR TITLE
fix: move @types/node to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   ],
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.0",
-    "@types/node": "^25.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^4.0.16",
@@ -86,6 +85,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@types/node": "^25.0.0",
     "axios": "^1.7.0",
     "https-proxy-agent": "^7.0.0",
     "jszip": "^3.10.0",


### PR DESCRIPTION
## Summary

Move `@types/node` from `devDependencies` to `dependencies` to fix the Release workflow MCPB Bundle job failure.

## Problem

The MCPB Bundle job installs only production dependencies (`npm ci --omit=dev`), but TypeScript compilation requires `@types/node` for Node.js built-in modules (`fs`, `https`) and globals (`Buffer`, `process`).

## Solution

Move `@types/node` to production dependencies so it's available during the MCPB bundle build step.

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI checks pass
- [ ] Release workflow MCPB Bundle job succeeds after merge

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)