### PR TITLE
fix: use correct mcpb pack positional arguments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         run: npm install -g @anthropic-ai/mcpb
 
       - name: Create MCPB bundle
-        run: mcpb pack --output f5xc-api-mcp-${{ needs.release.outputs.new_release_version }}.mcpb
+        run: mcpb pack . f5xc-api-mcp-${{ needs.release.outputs.new_release_version }}.mcpb
 
       - name: Upload MCPB to release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

Fix the MCPB Bundle step in the Release workflow by using correct `mcpb pack` CLI syntax.

## Problem

The Release workflow was using:
```bash
mcpb pack --output f5xc-api-mcp-VERSION.mcpb
```

But `mcpb pack` uses positional arguments, not `--output` flag:
```bash
mcpb pack [directory] [output]
```

This caused: `error: unknown option '--output'`

## Solution

Changed to correct positional syntax:
```bash
mcpb pack . f5xc-api-mcp-VERSION.mcpb
```

## Test plan

- [x] Pre-commit hooks pass
- [ ] CI checks pass
- [ ] Release workflow MCPB Bundle step succeeds on next release

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)