### PR TITLE
fix: pin npm version in Docker for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ FROM node:24-alpine AS production
 WORKDIR /app
 
 # Update npm to fix vulnerabilities (CVE-2024-21538, CVE-2025-64756)
-RUN npm install -g npm@latest
+# Pin to specific version for reproducible builds (update periodically)
+RUN npm install -g npm@11.7.0
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs && \


### PR DESCRIPTION
## Summary

Pin npm version in Dockerfile to ensure reproducible builds. This addresses the npm version update notices appearing during Docker build.

## Changes

- Change from `npm@latest` to `npm@11.7.0` in production stage
- Prevents different Docker builds from having different npm versions
- Improves build consistency across development and CI/CD environments
- Adds comment noting this should be updated periodically for security patches

## Rationale

Using `npm@latest` is problematic because:
- Each Docker build gets whatever the latest npm version is at build time
- Different builds on different days have different npm versions
- This reduces reproducibility and can cause unexpected behavior changes
- Best practice is to pin specific versions and update intentionally

## Testing

- Pre-commit hooks pass
- Docker build will now consistently use npm 11.7.0
- Reproducible builds across environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>