### PR TITLE
fix: remove sensitive token data from clear-text logging

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -257,7 +257,7 @@ export async function runSetupWizard(): Promise<void> {
         console.log(`   F5XC_API_URL: ${envCreds.apiUrl}`);
       }
       if (envCreds.apiToken) {
-        console.log(`   F5XC_API_TOKEN: ***${envCreds.apiToken.slice(-4)}`);
+        console.log(`   F5XC_API_TOKEN: ******* (configured)`);
       }
       if (envCreds.p12File) {
         console.log(`   F5XC_P12_FILE: ${envCreds.p12File}`);


### PR DESCRIPTION
## Summary
Fixes CodeQL security alert: Clear-text logging of sensitive information (HIGH severity).

Removes direct access to API token in logging context. Changed from:
```typescript
console.log(`F5XC_API_TOKEN: ***${envCreds.apiToken.slice(-4)}`);
```

To:
```typescript
console.log(`F5XC_API_TOKEN: ******* (configured)`);
```

## Compliance
- Resolves [CodeQL Alert #4](https://github.com/robinmordasiewicz/f5xc-api-mcp/security/code-scanning/4)
- Fixes CWE-312, CWE-359, CWE-532
- Maintains helpful user feedback
- No functional changes

Closes #57