### PR TITLE
fix: restore and properly configure pymdownx.emoji extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,9 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.caret
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
## Summary
Restore the pymdownx.emoji extension with proper configuration using YAML `!!python/name:` tag syntax instead of empty strings.

## Problem
The previous PR #64 removed the pymdownx.emoji extension due to a TypeError caused by misconfiguration with empty strings for `emoji_index` and `emoji_generator` parameters. The proper fix is to configure it correctly rather than removing it.

## Solution
Configured the extension with Material for MkDocs recommended settings:
- **emoji_index**: `!!python/name:material.extensions.emoji.twemoji` - Comprehensive emoji database
- **emoji_generator**: `!!python/name:material.extensions.emoji.to_svg` - SVG rendering for scalable emoji

The `!!python/name:` YAML tag properly resolves Python function references at configuration load time, fixing the TypeError that occurred when the extension tried to invoke empty string values.

## Changes
- Added properly configured `pymdownx.emoji` extension to mkdocs.yml (lines 79-81)
- Configuration uses Material theme's official emoji functions
- `attr_list` extension (required dependency) was already enabled

## Testing
- ✅ Documentation builds successfully in strict mode
- ✅ No TypeError from pymdownx.emoji extension
- ✅ All pre-commit hooks passed
- ⏳ Awaiting CI verification

## Technical Details
The error in PR #64 occurred because:
1. Empty strings were provided: `emoji_index: ""`
2. pymdownx.emoji expects callable function objects, not strings
3. Without `!!python/name:` YAML tag, configuration values are treated as literals
4. Extension attempted to invoke empty string, raising TypeError

The correct configuration uses the YAML Python name tag to reference Material's built-in emoji functions, which resolves to actual Python function objects at configuration initialization time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)