### PR TITLE
chore: add MkDocs directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ dist/
 build/
 *.egg-info/
 
+# MkDocs
+site/
+.cache/
+
 # Coverage
 coverage/
 


### PR DESCRIPTION
## Summary
Add MkDocs auto-generated directories to .gitignore to prevent accidental commits.

## Changes
Added to `.gitignore`:
- `site/` - MkDocs build output directory
- `.cache/` - MkDocs plugin cache (social cards images, manifest, etc.)

These directories are regenerated on every `mkdocs build` and should not be version controlled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)