### PR TITLE
feat: register dependency discovery tools in MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/tools/generated/*.json dist/tools/generated/",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "test": "vitest run",

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,8 +26,11 @@ import {
   resolveConsolidatedTool,
   getConsolidatedResource,
   getConsolidationStats,
+  generateDependencyReport,
+  getDependencyStats,
   type CrudOperation,
 } from "./tools/discovery/index.js";
+import type { DependencyDiscoveryAction } from "./generator/dependency-types.js";
 
 /**
  * Server configuration options
@@ -135,6 +138,8 @@ export class F5XCApiServer {
                     "f5xc-api-execute-tool",
                     "f5xc-api-search-resources",
                     "f5xc-api-execute-resource",
+                    "f5xc-api-dependencies",
+                    "f5xc-api-dependency-stats",
                   ],
                   message: isAuthenticated
                     ? "Authenticated - API execution enabled. Use f5xc-api-search-tools to find available API tools."
@@ -397,12 +402,58 @@ export class F5XCApiServer {
       }
     );
 
+    // Dependencies tool - get resource dependency information
+    this.server.tool(
+      DISCOVERY_TOOLS.dependencies.name,
+      DISCOVERY_TOOLS.dependencies.description,
+      {
+        resource: z.string().describe("Resource name (e.g., 'http-loadbalancer')"),
+        domain: z.string().describe("Domain containing the resource (e.g., 'virtual')"),
+        action: z
+          .enum(["prerequisites", "dependents", "oneOf", "subscriptions", "creationOrder", "full"])
+          .optional()
+          .describe("Type of dependency information to retrieve (default: 'full')"),
+      },
+      async (args) => {
+        const action = (args.action ?? "full") as DependencyDiscoveryAction;
+        const report = generateDependencyReport(args.domain, args.resource, action);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(report, null, 2),
+            },
+          ],
+        };
+      }
+    );
+
+    // Dependency stats tool - get graph statistics
+    this.server.tool(
+      DISCOVERY_TOOLS.dependencyStats.name,
+      DISCOVERY_TOOLS.dependencyStats.description,
+      {},
+      async () => {
+        const stats = getDependencyStats();
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(stats, null, 2),
+            },
+          ],
+        };
+      }
+    );
+
     const indexMetadata = getIndexMetadata();
     const consolidationStats = getConsolidationStats();
     logger.info("Tool registration completed (dynamic discovery mode)", {
       authMode,
       authenticated: authMode !== AuthMode.NONE,
-      registeredTools: 6,
+      registeredTools: 8,
       indexedTools: indexMetadata.totalTools,
       consolidatedResources: consolidationStats.consolidatedCount,
       consolidationReduction: consolidationStats.reductionPercent,


### PR DESCRIPTION
## Summary
- Add f5xc-api-dependencies and f5xc-api-dependency-stats tools to MCP server
- Fix build script to copy JSON files (dependency-graph.json) to dist directory
- Update server info to list all 8 discovery tools

## Changes
- src/server.ts: Register the two new dependency tools with proper Zod schemas
- package.json: Update build script to copy JSON files from src to dist

## Test plan
- [x] `npm run build` copies dependency-graph.json to dist
- [x] All 1366 tests pass
- [x] MCP tools list shows 8 tools including f5xc-api-dependencies
- [x] f5xc-api-dependency-stats returns graph statistics
- [x] f5xc-api-dependencies returns resource relationship info

🤖 Generated with [Claude Code](https://claude.com/claude-code)