### PR TITLE
feat: add Phase A metadata surfacing enhancements

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -161,6 +161,8 @@ function generateDomainFile(
     dependencies: ${deterministicStringify(op.dependencies).replace(/\n/g, "\n    ")},
     oneOfGroups: ${deterministicStringify(op.oneOfGroups).replace(/\n/g, "\n    ")},
     subscriptionRequirements: ${deterministicStringify(op.subscriptionRequirements).replace(/\n/g, "\n    ")},
+    isDeprecated: ${op.isDeprecated},
+    deprecationMessage: ${op.deprecationMessage ? JSON.stringify(op.deprecationMessage) : "null"},
   }`;
   });
 

--- a/src/generator/openapi-parser.ts
+++ b/src/generator/openapi-parser.ts
@@ -129,6 +129,8 @@ const OpenApiOperationSchema = z.object({
   "x-ves-required-fields": z.array(z.string()).optional(),
   "x-ves-confirmation-required": z.boolean().optional(),
   "x-ves-operation-metadata": OperationMetadataSchema.optional(),
+  // Deprecation field from enriched specs
+  "x-ves-deprecated": z.string().optional(),
 });
 
 const OpenApiPathItemSchema = z.object({
@@ -283,6 +285,12 @@ export interface ParsedOperation {
   oneOfGroups: OneOfGroup[];
   /** Subscription/addon service requirements */
   subscriptionRequirements: SubscriptionRequirement[];
+
+  // Deprecation fields (Phase A enhancement)
+  /** Whether this operation is deprecated */
+  isDeprecated: boolean;
+  /** Deprecation message with migration guidance */
+  deprecationMessage: string | null;
 }
 
 /**
@@ -617,6 +625,9 @@ function extractOperations(
         dependencies,
         oneOfGroups: extractedDeps.oneOfGroups,
         subscriptionRequirements,
+        // Deprecation (Phase A enhancement) - defaults for legacy parser
+        isDeprecated: false,
+        deprecationMessage: null,
       });
     }
   }
@@ -816,6 +827,10 @@ function extractDomainOperations(
       const confirmationRequired = operation["x-ves-confirmation-required"] ?? false;
       const operationMetadata = operation["x-ves-operation-metadata"] ?? null;
 
+      // Extract deprecation status (Phase A enhancement)
+      const deprecationMessage = operation["x-ves-deprecated"] ?? null;
+      const isDeprecated = deprecationMessage !== null;
+
       // Extract parameter-level metadata (examples, validation rules, displaynames)
       const parameterExamples: Record<string, string> = {};
       const validationRules: Record<string, Record<string, string>> = {};
@@ -891,6 +906,9 @@ function extractDomainOperations(
         dependencies,
         oneOfGroups: extractedDeps.oneOfGroups,
         subscriptionRequirements,
+        // Deprecation (Phase A enhancement)
+        isDeprecated,
+        deprecationMessage,
       });
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -163,12 +163,16 @@ export class F5XCApiServer {
         limit: z.number().optional().describe("Maximum results (default: 10)"),
         domains: z.array(z.string()).optional().describe("Filter by domains"),
         operations: z.array(z.string()).optional().describe("Filter by operations"),
+        excludeDangerous: z.boolean().optional().describe("Exclude high-danger operations"),
+        excludeDeprecated: z.boolean().optional().describe("Exclude deprecated operations"),
       },
       async (args) => {
         const results = searchTools(args.query, {
           limit: Math.min(args.limit ?? 10, 50),
           domains: args.domains,
           operations: args.operations,
+          excludeDangerous: args.excludeDangerous,
+          excludeDeprecated: args.excludeDeprecated,
         });
 
         return {
@@ -186,6 +190,9 @@ export class F5XCApiServer {
                     operation: r.tool.operation,
                     summary: r.tool.summary,
                     score: Math.round(r.score * 100) / 100,
+                    // Phase A enhancement fields
+                    dangerLevel: r.tool.dangerLevel,
+                    isDeprecated: r.tool.isDeprecated,
                   })),
                   hint: "Use f5xc-api-describe-tool to get full schema for a specific tool.",
                 },

--- a/src/tools/discovery/describe.ts
+++ b/src/tools/discovery/describe.ts
@@ -5,7 +5,8 @@
  * This implements lazy loading to avoid upfront token consumption.
  */
 
-import type { ParsedOperation } from "../../generator/openapi-parser.js";
+import type { ParsedOperation, CommonError } from "../../generator/openapi-parser.js";
+import type { OneOfGroup } from "../../generator/dependency-types.js";
 import { getToolByName } from "../registry.js";
 import { toolExists, getToolEntry, getToolIndex } from "./index-loader.js";
 
@@ -40,6 +41,17 @@ export interface ToolDescription {
   hasRequestBody: boolean;
   /** Request body schema reference (if any) */
   requestBodyRef: string | null;
+  // Phase A enhancement fields
+  /** Risk level for the operation */
+  dangerLevel: "low" | "medium" | "high" | null;
+  /** Whether this operation is deprecated */
+  isDeprecated: boolean;
+  /** Deprecation message with migration guidance */
+  deprecationMessage: string | null;
+  /** Mutually exclusive field groups (choose one of) */
+  oneOfGroups: OneOfGroup[];
+  /** Common errors that may occur with this operation */
+  commonErrors: CommonError[];
 }
 
 /**
@@ -148,6 +160,12 @@ export function describeTool(toolName: string): ToolDescription | null {
     queryParameters: tool.queryParameters.map(extractParameterDescription),
     hasRequestBody: tool.requestBodySchema !== null,
     requestBodyRef,
+    // Phase A enhancement fields
+    dangerLevel: tool.dangerLevel,
+    isDeprecated: tool.isDeprecated,
+    deprecationMessage: tool.deprecationMessage,
+    oneOfGroups: tool.oneOfGroups,
+    commonErrors: tool.operationMetadata?.common_errors ?? [],
   };
 }
 

--- a/src/tools/discovery/index-loader.ts
+++ b/src/tools/discovery/index-loader.ts
@@ -21,6 +21,9 @@ function generateIndex(): ToolIndex {
     resource: tool.resource,
     operation: tool.operation,
     summary: tool.summary,
+    // Phase A enhancement fields
+    dangerLevel: tool.dangerLevel,
+    isDeprecated: tool.isDeprecated,
   }));
 
   // Calculate domain counts

--- a/src/tools/discovery/index.ts
+++ b/src/tools/discovery/index.ts
@@ -125,6 +125,14 @@ export const DISCOVERY_TOOLS = {
           items: { type: "string" },
           description: "Filter by operation type(s): create, get, list, update, delete",
         },
+        excludeDangerous: {
+          type: "boolean",
+          description: "Exclude high-danger operations from results",
+        },
+        excludeDeprecated: {
+          type: "boolean",
+          description: "Exclude deprecated operations from results",
+        },
       },
       required: ["query"],
     },

--- a/src/tools/discovery/search.ts
+++ b/src/tools/discovery/search.ts
@@ -118,7 +118,14 @@ function calculateScore(
  * ```
  */
 export function searchTools(query: string, options: SearchOptions = {}): SearchResult[] {
-  const { limit = 10, domains, operations, minScore = 0.1 } = options;
+  const {
+    limit = 10,
+    domains,
+    operations,
+    minScore = 0.1,
+    excludeDangerous,
+    excludeDeprecated,
+  } = options;
 
   const index = getToolIndex();
   let tools = index.tools;
@@ -133,6 +140,16 @@ export function searchTools(query: string, options: SearchOptions = {}): SearchR
   if (operations && operations.length > 0) {
     const opSet = new Set(operations.map((o) => o.toLowerCase()));
     tools = tools.filter((t) => opSet.has(t.operation.toLowerCase()));
+  }
+
+  // Phase A enhancement: Apply danger filter
+  if (excludeDangerous) {
+    tools = tools.filter((t) => t.dangerLevel !== "high");
+  }
+
+  // Phase A enhancement: Apply deprecation filter
+  if (excludeDeprecated) {
+    tools = tools.filter((t) => !t.isDeprecated);
   }
 
   // Score and rank tools

--- a/src/tools/discovery/types.ts
+++ b/src/tools/discovery/types.ts
@@ -21,6 +21,11 @@ export interface ToolIndexEntry {
   operation: string;
   /** Brief summary for search matching */
   summary: string;
+  // Phase A enhancement fields
+  /** Risk level for the operation (from x-ves-danger-level) */
+  dangerLevel: "low" | "medium" | "high" | null;
+  /** Whether this operation is deprecated */
+  isDeprecated: boolean;
 }
 
 /**
@@ -47,6 +52,11 @@ export interface SearchOptions {
   operations?: string[];
   /** Minimum relevance score threshold (default: 0.1) */
   minScore?: number;
+  // Phase A enhancement filters
+  /** Exclude high-danger operations from results */
+  excludeDangerous?: boolean;
+  /** Exclude deprecated operations from results */
+  excludeDeprecated?: boolean;
 }
 
 /**

--- a/src/tools/generated/admin_console_and_ui/index.ts
+++ b/src/tools/generated/admin_console_and_ui/index.ts
@@ -130,6 +130,8 @@ export const admin_console_and_uiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-adminconsoleandui-static-component-list",
@@ -264,6 +266,8 @@ export const admin_console_and_uiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/api/index.ts
+++ b/src/tools/generated/api/index.ts
@@ -142,6 +142,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-crawler-delete",
@@ -274,6 +276,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-crawler-get",
@@ -416,6 +420,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-crawler-list",
@@ -564,6 +570,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-crawler-update",
@@ -713,6 +721,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-definition-create",
@@ -850,6 +860,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-definition-delete",
@@ -982,6 +994,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-definition-get",
@@ -1124,6 +1138,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-definition-list",
@@ -1272,6 +1288,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-definition-update",
@@ -1421,6 +1439,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-definitions-without-shared-list",
@@ -1531,6 +1551,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-discovery-create",
@@ -1668,6 +1690,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-discovery-delete",
@@ -1799,6 +1823,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-discovery-get",
@@ -1941,6 +1967,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-discovery-list",
@@ -2088,6 +2116,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-discovery-update",
@@ -2237,6 +2267,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-endpoint-protection-create",
@@ -2354,6 +2386,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-group-element-get",
@@ -2494,6 +2528,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-group-element-list",
@@ -2641,6 +2677,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-group-get",
@@ -2780,6 +2818,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-group-list",
@@ -2927,6 +2967,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-testing-create",
@@ -3064,6 +3106,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-testing-delete",
@@ -3196,6 +3240,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-testing-get",
@@ -3338,6 +3384,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-testing-list",
@@ -3486,6 +3534,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-api-testing-update",
@@ -3635,6 +3685,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-app-api-group-create",
@@ -3773,6 +3825,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-app-api-group-delete",
@@ -3905,6 +3959,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-app-api-group-get",
@@ -4048,6 +4104,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-app-api-group-list",
@@ -4196,6 +4254,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-app-api-group-update",
@@ -4346,6 +4406,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-code-base-integration-create",
@@ -4486,6 +4548,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-code-base-integration-delete",
@@ -4618,6 +4682,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-code-base-integration-get",
@@ -4760,6 +4826,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-code-base-integration-list",
@@ -4908,6 +4976,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-code-base-integration-update",
@@ -5057,6 +5127,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-data-exposure-create",
@@ -5171,6 +5243,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-discovery-create",
@@ -5307,6 +5381,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-discovery-delete",
@@ -5438,6 +5514,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-discovery-get",
@@ -5579,6 +5657,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-discovery-list",
@@ -5726,6 +5806,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-discovery-update",
@@ -5874,6 +5956,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-download-certificate-create",
@@ -6004,6 +6088,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-evaluate-create",
@@ -6126,6 +6212,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-loadbalancer-get",
@@ -6246,6 +6334,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-mark-as-non-api-create",
@@ -6369,6 +6459,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-move-to-inventory-create",
@@ -6495,6 +6587,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-oas-validation-create",
@@ -6609,6 +6703,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-rate-limit-create",
@@ -6723,6 +6819,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-remove-from-inventory-create",
@@ -6849,6 +6947,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-stat-create",
@@ -6963,6 +7063,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-api-unmark-as-non-api-create",
@@ -7089,6 +7191,8 @@ export const apiTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/authentication/index.ts
+++ b/src/tools/generated/authentication/index.ts
@@ -90,6 +90,8 @@ export const authenticationTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-api-credential-get",
@@ -197,6 +199,8 @@ export const authenticationTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-api-credential-list",
@@ -292,6 +296,8 @@ export const authenticationTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-scim-token-create",
@@ -399,6 +405,8 @@ export const authenticationTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-scim-token-list",
@@ -501,6 +509,8 @@ export const authenticationTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-service-credential-create",
@@ -589,6 +599,8 @@ export const authenticationTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-service-credential-get",
@@ -696,6 +708,8 @@ export const authenticationTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-service-credential-list",
@@ -790,6 +804,8 @@ export const authenticationTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-authentication-service-credential-update",
@@ -912,6 +928,8 @@ export const authenticationTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/bigip/index.ts
+++ b/src/tools/generated/bigip/index.ts
@@ -129,6 +129,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-apm-delete",
@@ -248,6 +250,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-apm-get",
@@ -377,6 +381,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-apm-list",
@@ -512,6 +518,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-apm-update",
@@ -648,6 +656,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-irule-create",
@@ -771,6 +781,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-irule-delete",
@@ -889,6 +901,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-irule-get",
@@ -1017,6 +1031,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-irule-list",
@@ -1151,6 +1167,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-irule-update",
@@ -1286,6 +1304,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-virtual-server-get",
@@ -1414,6 +1434,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-virtual-server-list",
@@ -1549,6 +1571,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-bigip-virtual-server-update",
@@ -1685,6 +1709,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-data-group-create",
@@ -1810,6 +1836,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-data-group-delete",
@@ -1929,6 +1957,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-data-group-get",
@@ -2057,6 +2087,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-data-group-list",
@@ -2192,6 +2224,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-data-group-update",
@@ -2328,6 +2362,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-get-security-config-create",
@@ -2438,6 +2474,8 @@ export const bigipTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-irule-create",
@@ -2562,6 +2600,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-irule-delete",
@@ -2681,6 +2721,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-irule-get",
@@ -2809,6 +2851,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-irule-list",
@@ -2944,6 +2988,8 @@ export const bigipTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-irule-update",
@@ -3080,6 +3126,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-bigip-metric-create",
@@ -3188,6 +3236,8 @@ export const bigipTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/billing_and_usage/index.ts
+++ b/src/tools/generated/billing_and_usage/index.ts
@@ -85,6 +85,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-current-usage-create",
@@ -186,6 +188,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-custom-list-list",
@@ -266,6 +270,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-hourly-usage-detail-create",
@@ -370,6 +376,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-invoice-pdf-list",
@@ -477,6 +485,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-limit-list",
@@ -571,6 +581,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-monthly-usage-create",
@@ -672,6 +684,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-payment-method-create",
@@ -781,6 +795,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-payment-method-delete",
@@ -889,6 +905,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-plan-transition-create",
@@ -990,6 +1008,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-plan-transition-list",
@@ -1085,6 +1105,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-primary-create",
@@ -1196,6 +1218,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-quota-create",
@@ -1319,6 +1343,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-quota-delete",
@@ -1437,6 +1463,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-quota-get",
@@ -1565,6 +1593,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-quota-list",
@@ -1699,6 +1729,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-quota-update",
@@ -1835,6 +1867,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-secondary-create",
@@ -1946,6 +1980,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-subscribe-create",
@@ -2052,6 +2088,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-swap-primary-create",
@@ -2163,6 +2201,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-unsubscribe-create",
@@ -2269,6 +2309,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-usage-detail-create",
@@ -2370,6 +2412,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-billingandusage-usage-list",
@@ -2464,6 +2508,8 @@ export const billing_and_usageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/blindfold/index.ts
+++ b/src/tools/generated/blindfold/index.ts
@@ -107,6 +107,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-aggregation-create",
@@ -208,6 +210,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-audit-log-create",
@@ -309,6 +313,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-decrypt-secret-create",
@@ -404,6 +410,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-get-policy-document-get",
@@ -511,6 +519,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-get-public-key-list",
@@ -607,6 +617,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-list-policy-list",
@@ -713,6 +725,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-process-policy-information-create",
@@ -811,6 +825,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-recover-create",
@@ -923,6 +939,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-scroll-create",
@@ -1025,6 +1043,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-scroll-list",
@@ -1134,6 +1154,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-management-access-create",
@@ -1261,6 +1283,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-management-access-delete",
@@ -1379,6 +1403,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-management-access-get",
@@ -1508,6 +1534,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-management-access-list",
@@ -1642,6 +1670,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-management-access-update",
@@ -1778,6 +1808,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-create",
@@ -1902,6 +1934,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-delete",
@@ -2020,6 +2054,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-get",
@@ -2149,6 +2185,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-list",
@@ -2283,6 +2321,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-rule-create",
@@ -2410,6 +2450,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-rule-delete",
@@ -2528,6 +2570,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-rule-get",
@@ -2657,6 +2701,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-rule-list",
@@ -2791,6 +2837,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-rule-update",
@@ -2927,6 +2975,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-secret-policy-update",
@@ -3063,6 +3113,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-softdelete-create",
@@ -3183,6 +3235,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-voltshare-admin-policy-create",
@@ -3310,6 +3364,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-voltshare-admin-policy-delete",
@@ -3428,6 +3484,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-voltshare-admin-policy-get",
@@ -3557,6 +3615,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-voltshare-admin-policy-list",
@@ -3691,6 +3751,8 @@ export const blindfoldTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-blindfold-voltshare-admin-policy-update",
@@ -3827,6 +3889,8 @@ export const blindfoldTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/bot_and_threat_defense/index.ts
+++ b/src/tools/generated/bot_and_threat_defense/index.ts
@@ -145,6 +145,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-bot-defense-app-infrastructure-delete",
@@ -277,6 +279,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-bot-defense-app-infrastructure-get",
@@ -418,6 +422,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-bot-defense-app-infrastructure-list",
@@ -566,6 +572,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-bot-defense-app-infrastructure-update",
@@ -715,6 +723,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-preauth-create",
@@ -814,6 +824,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-provision-create",
@@ -913,6 +925,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-shape-bot-defense-instance-get",
@@ -1052,6 +1066,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-shape-bot-defense-instance-list",
@@ -1200,6 +1216,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-api-key-create",
@@ -1337,6 +1355,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-api-key-get",
@@ -1478,6 +1498,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-api-key-list",
@@ -1625,6 +1647,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-api-key-update",
@@ -1774,6 +1798,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-category-create",
@@ -1911,6 +1937,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-category-get",
@@ -2052,6 +2080,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-category-list",
@@ -2199,6 +2229,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-category-update",
@@ -2347,6 +2379,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-manager-create",
@@ -2483,6 +2517,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-manager-get",
@@ -2623,6 +2659,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-botandthreatdefense-tpm-manager-list",
@@ -2770,6 +2808,8 @@ export const bot_and_threat_defenseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/cdn/index.ts
+++ b/src/tools/generated/cdn/index.ts
@@ -112,6 +112,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-aggregation-create",
@@ -220,6 +222,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cache-purge-create",
@@ -350,6 +354,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-cache-rule-create",
@@ -481,6 +487,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-cache-rule-delete",
@@ -607,6 +615,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-cache-rule-get",
@@ -742,6 +752,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-cache-rule-list",
@@ -884,6 +896,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-cache-rule-update",
@@ -1027,6 +1041,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-loadbalancer-create",
@@ -1161,6 +1177,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-loadbalancer-delete",
@@ -1287,6 +1305,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-loadbalancer-get",
@@ -1423,6 +1443,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-loadbalancer-list",
@@ -1565,6 +1587,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-cdn-loadbalancer-update",
@@ -1708,6 +1732,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-dos-automitigation-rule-delete",
@@ -1839,6 +1865,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-dos-automitigation-rule-get",
@@ -1953,6 +1981,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-get-security-config-create",
@@ -2069,6 +2099,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-get-service-operation-statu-create",
@@ -2179,6 +2211,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-list-service-operations-statu-create",
@@ -2295,6 +2329,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-metric-create",
@@ -2402,6 +2438,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-subscribe-create",
@@ -2495,6 +2533,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-suggestion-create",
@@ -2613,6 +2653,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cdn-unsubscribe-create",
@@ -2706,6 +2748,8 @@ export const cdnTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/ce_management/index.ts
+++ b/src/tools/generated/ce_management/index.ts
@@ -128,6 +128,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-fleet-create",
@@ -259,6 +261,8 @@ export const ce_managementTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-fleet-delete",
@@ -385,6 +389,8 @@ export const ce_managementTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-fleet-get",
@@ -521,6 +527,8 @@ export const ce_managementTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-fleet-list",
@@ -663,6 +671,8 @@ export const ce_managementTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-fleet-update",
@@ -806,6 +816,8 @@ export const ce_managementTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-get-image-download-url-create",
@@ -895,6 +907,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-get-registrations-by-token-create",
@@ -991,6 +1005,8 @@ export const ce_managementTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-listregistrationsbystate-create",
@@ -1096,6 +1112,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-network-interface-create",
@@ -1224,6 +1242,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-network-interface-delete",
@@ -1343,6 +1363,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-network-interface-get",
@@ -1472,6 +1494,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-network-interface-list",
@@ -1607,6 +1631,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-network-interface-update",
@@ -1744,6 +1770,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-pre-upgrade-check-get",
@@ -1863,6 +1891,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-registerbootstrap-create",
@@ -1975,6 +2005,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-registration-create",
@@ -2098,6 +2130,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-registration-delete",
@@ -2218,6 +2252,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-registration-get",
@@ -2345,6 +2381,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-registration-list",
@@ -2479,6 +2517,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-registration-update",
@@ -2614,6 +2654,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-registrations-by-site-list",
@@ -2728,6 +2770,8 @@ export const ce_managementTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-requestconfig-create",
@@ -2815,6 +2859,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-setting-list",
@@ -2909,6 +2955,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-suggest-value-create",
@@ -2996,6 +3044,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-upgradable-sw-version-list",
@@ -3102,6 +3152,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-upgrade-statu-get",
@@ -3208,6 +3260,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-usb-policy-create",
@@ -3331,6 +3385,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-usb-policy-delete",
@@ -3449,6 +3505,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-usb-policy-get",
@@ -3577,6 +3635,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-usb-policy-list",
@@ -3711,6 +3771,8 @@ export const ce_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cemanagement-usb-policy-update",
@@ -3846,6 +3908,8 @@ export const ce_managementTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/certificates/index.ts
+++ b/src/tools/generated/certificates/index.ts
@@ -132,6 +132,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-chain-delete",
@@ -251,6 +253,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-chain-get",
@@ -380,6 +384,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-chain-list",
@@ -515,6 +521,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-chain-update",
@@ -651,6 +659,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-create",
@@ -775,6 +785,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-delete",
@@ -894,6 +906,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-get",
@@ -1023,6 +1037,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-list",
@@ -1158,6 +1174,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-certificate-update",
@@ -1294,6 +1312,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-crl-create",
@@ -1418,6 +1438,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-crl-delete",
@@ -1537,6 +1559,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-crl-get",
@@ -1666,6 +1690,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-crl-list",
@@ -1801,6 +1827,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-crl-update",
@@ -1937,6 +1965,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-trusted-ca-list-create",
@@ -2061,6 +2091,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-trusted-ca-list-delete",
@@ -2180,6 +2212,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-trusted-ca-list-get",
@@ -2309,6 +2343,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-trusted-ca-list-list",
@@ -2444,6 +2480,8 @@ export const certificatesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-certificates-trusted-ca-list-update",
@@ -2580,6 +2618,8 @@ export const certificatesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/cloud_infrastructure/index.ts
+++ b/src/tools/generated/cloud_infrastructure/index.ts
@@ -132,6 +132,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-certified-hardware-list",
@@ -267,6 +269,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-connect-create",
@@ -391,6 +395,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-connect-delete",
@@ -510,6 +516,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-connect-get",
@@ -639,6 +647,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-connect-list",
@@ -774,6 +784,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-connect-reapply-vpc-attachment-create",
@@ -878,6 +890,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-connect-update",
@@ -1014,6 +1028,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-credentials-create",
@@ -1140,6 +1156,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-credentials-delete",
@@ -1258,6 +1276,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-credentials-get",
@@ -1386,6 +1406,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-credentials-list",
@@ -1520,6 +1542,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-credentials-update",
@@ -1655,6 +1679,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-elastic-ip-create",
@@ -1783,6 +1809,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-elastic-ip-delete",
@@ -1902,6 +1930,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-elastic-ip-get",
@@ -2032,6 +2062,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-elastic-ip-list",
@@ -2167,6 +2199,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-elastic-ip-update",
@@ -2303,6 +2337,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-link-create",
@@ -2427,6 +2463,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-link-delete",
@@ -2546,6 +2584,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-link-get",
@@ -2675,6 +2715,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-link-list",
@@ -2810,6 +2852,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-link-update",
@@ -2946,6 +2990,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-region-get",
@@ -3074,6 +3120,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-region-list",
@@ -3209,6 +3257,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-cloud-region-update",
@@ -3345,6 +3395,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-discover-vpc-create",
@@ -3454,6 +3506,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-edge-credential-create",
@@ -3548,6 +3602,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-edge-list-list",
@@ -3628,6 +3684,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-force-delete-create",
@@ -3728,6 +3786,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-metric-create",
@@ -3814,6 +3874,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-reapply-config-create",
@@ -3914,6 +3976,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-cloudinfrastructure-segment-metric-create",
@@ -4000,6 +4064,8 @@ export const cloud_infrastructureTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/container_services/index.ts
+++ b/src/tools/generated/container_services/index.ts
@@ -114,6 +114,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-virtual-k8s-create",
@@ -238,6 +240,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-virtual-k8s-delete",
@@ -356,6 +360,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-virtual-k8s-get",
@@ -485,6 +491,8 @@ export const container_servicesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-virtual-k8s-list",
@@ -619,6 +627,8 @@ export const container_servicesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-virtual-k8s-update",
@@ -755,6 +765,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-create",
@@ -879,6 +891,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-delete",
@@ -998,6 +1012,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-flavor-create",
@@ -1122,6 +1138,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-flavor-delete",
@@ -1241,6 +1259,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-flavor-get",
@@ -1370,6 +1390,8 @@ export const container_servicesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-flavor-list",
@@ -1505,6 +1527,8 @@ export const container_servicesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-flavor-update",
@@ -1641,6 +1665,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-get",
@@ -1770,6 +1796,8 @@ export const container_servicesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-list",
@@ -1905,6 +1933,8 @@ export const container_servicesTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-containerservices-workload-update",
@@ -2041,6 +2071,8 @@ export const container_servicesTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/data_and_privacy_security/index.ts
+++ b/src/tools/generated/data_and_privacy_security/index.ts
@@ -130,6 +130,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-data-type-delete",
@@ -249,6 +251,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-data-type-get",
@@ -378,6 +382,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-data-type-list",
@@ -513,6 +519,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-data-type-update",
@@ -650,6 +658,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-geo-config-get",
@@ -777,6 +787,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-lma-region-get",
@@ -904,6 +916,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-lma-region-list",
@@ -1039,6 +1053,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-sensitive-data-policy-create",
@@ -1166,6 +1182,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-sensitive-data-policy-delete",
@@ -1284,6 +1302,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-sensitive-data-policy-get",
@@ -1413,6 +1433,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-sensitive-data-policy-list",
@@ -1547,6 +1569,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataandprivacysecurity-sensitive-data-policy-update",
@@ -1683,6 +1707,8 @@ export const data_and_privacy_securityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/data_intelligence/index.ts
+++ b/src/tools/generated/data_intelligence/index.ts
@@ -99,6 +99,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-dataset-list",
@@ -179,6 +181,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-flowlabel-list",
@@ -273,6 +277,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-init-request-create",
@@ -359,6 +365,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-receiver-create",
@@ -482,6 +490,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-receiver-delete",
@@ -600,6 +610,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-receiver-get",
@@ -728,6 +740,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-receiver-list",
@@ -862,6 +876,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-receiver-update",
@@ -997,6 +1013,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-statu-create",
@@ -1117,6 +1135,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-subscribe-create",
@@ -1203,6 +1223,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-suggest-value-create",
@@ -1304,6 +1326,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-summary-create",
@@ -1404,6 +1428,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-test-create",
@@ -1516,6 +1542,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dataintelligence-unsubscribe-create",
@@ -1602,6 +1630,8 @@ export const data_intelligenceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/ddos/index.ts
+++ b/src/tools/generated/ddos/index.ts
@@ -85,6 +85,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-alert-create",
@@ -186,6 +188,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-alert-list",
@@ -292,6 +296,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-annotation-list",
@@ -398,6 +404,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-attachment-list",
@@ -505,6 +513,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-bgp-peer-statu-create",
@@ -605,6 +615,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-detail-create",
@@ -717,6 +729,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-detail-delete",
@@ -839,6 +853,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-detail-list",
@@ -946,6 +962,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-detail-update",
@@ -1070,6 +1088,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-event-create",
@@ -1171,6 +1191,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-event-list",
@@ -1278,6 +1300,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-event-update",
@@ -1391,6 +1415,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-events-summary-list",
@@ -1499,6 +1525,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-create",
@@ -1625,6 +1653,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-delete",
@@ -1743,6 +1773,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-get",
@@ -1871,6 +1903,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-list",
@@ -2005,6 +2039,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-prefix-create",
@@ -2131,6 +2167,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-prefix-delete",
@@ -2249,6 +2287,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-prefix-get",
@@ -2377,6 +2417,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-prefix-list",
@@ -2511,6 +2553,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-prefix-update",
@@ -2646,6 +2690,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-asn-update",
@@ -2781,6 +2827,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-deny-list-rule-create",
@@ -2907,6 +2955,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-deny-list-rule-delete",
@@ -3025,6 +3075,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-deny-list-rule-get",
@@ -3153,6 +3205,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-deny-list-rule-list",
@@ -3287,6 +3341,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-deny-list-rule-update",
@@ -3422,6 +3478,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-create",
@@ -3548,6 +3606,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-delete",
@@ -3666,6 +3726,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-get",
@@ -3794,6 +3856,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-group-create",
@@ -3920,6 +3984,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-group-delete",
@@ -4038,6 +4104,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-group-get",
@@ -4166,6 +4234,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-group-list",
@@ -4301,6 +4371,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-group-update",
@@ -4436,6 +4508,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-list",
@@ -4570,6 +4644,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-rule-update",
@@ -4705,6 +4781,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-ruleset-get",
@@ -4832,6 +4910,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-ruleset-list",
@@ -4966,6 +5046,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-firewall-ruleset-update",
@@ -5101,6 +5183,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-information-get",
@@ -5227,6 +5311,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-internet-prefix-advertisement-create",
@@ -5353,6 +5439,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-internet-prefix-advertisement-delete",
@@ -5471,6 +5559,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-internet-prefix-advertisement-get",
@@ -5599,6 +5689,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-internet-prefix-advertisement-list",
@@ -5734,6 +5826,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-internet-prefix-advertisement-update",
@@ -5869,6 +5963,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-tunnel-create",
@@ -6002,6 +6098,8 @@ export const ddosTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-tunnel-delete",
@@ -6127,6 +6225,8 @@ export const ddosTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-tunnel-get",
@@ -6262,6 +6362,8 @@ export const ddosTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-tunnel-list",
@@ -6403,6 +6505,8 @@ export const ddosTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-infraprotect-tunnel-update",
@@ -6545,6 +6649,8 @@ export const ddosTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-ip-list",
@@ -6652,6 +6758,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-mitigation-annotation-list",
@@ -6758,6 +6866,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-mitigation-create",
@@ -6858,6 +6968,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-mitigation-list",
@@ -6964,6 +7076,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-network-list",
@@ -7059,6 +7173,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-report-create",
@@ -7160,6 +7276,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-report-list",
@@ -7266,6 +7384,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-suggest-value-create",
@@ -7367,6 +7487,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-to-event-update",
@@ -7480,6 +7602,8 @@ export const ddosTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-transit-usage-create",
@@ -7588,6 +7712,8 @@ export const ddosTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-update-advertisement-statu-create",
@@ -7699,6 +7825,8 @@ export const ddosTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-update-asn-prefix-irr-override-create",
@@ -7809,6 +7937,8 @@ export const ddosTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-update-asn-prefix-review-statu-create",
@@ -7919,6 +8049,8 @@ export const ddosTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-update-asn-review-statu-create",
@@ -8029,6 +8161,8 @@ export const ddosTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ddos-update-tunnel-statu-create",
@@ -8140,6 +8274,8 @@ export const ddosTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/dns/index.ts
+++ b/src/tools/generated/dns/index.ts
@@ -94,6 +94,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-compliance-checks-create",
@@ -221,6 +223,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-compliance-checks-delete",
@@ -339,6 +343,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-compliance-checks-get",
@@ -467,6 +473,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-compliance-checks-list",
@@ -601,6 +609,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-compliance-checks-update",
@@ -736,6 +746,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-domain-create",
@@ -861,6 +873,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-domain-delete",
@@ -980,6 +994,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-domain-get",
@@ -1109,6 +1125,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-domain-list",
@@ -1244,6 +1262,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-domain-update",
@@ -1380,6 +1400,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-health-check-create",
@@ -1507,6 +1529,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-health-check-delete",
@@ -1625,6 +1649,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-health-check-get",
@@ -1753,6 +1779,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-health-check-list",
@@ -1887,6 +1915,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-health-check-update",
@@ -2022,6 +2052,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-pool-create",
@@ -2146,6 +2178,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-pool-delete",
@@ -2264,6 +2298,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-pool-get",
@@ -2392,6 +2428,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-pool-list",
@@ -2526,6 +2564,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-lb-pool-update",
@@ -2661,6 +2701,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-load-balancer-create",
@@ -2788,6 +2830,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-load-balancer-delete",
@@ -2906,6 +2950,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-load-balancer-get",
@@ -3034,6 +3080,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-load-balancer-list",
@@ -3168,6 +3216,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-load-balancer-update",
@@ -3303,6 +3353,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-zone-create",
@@ -3426,6 +3478,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-zone-delete",
@@ -3544,6 +3598,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-zone-get",
@@ -3672,6 +3728,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-zone-list",
@@ -3806,6 +3864,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-dns-zone-update",
@@ -3941,6 +4001,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-export-list",
@@ -4047,6 +4109,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-health-statu-get",
@@ -4153,6 +4217,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-health-statu-list",
@@ -4247,6 +4313,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-health-status-change-event-list",
@@ -4390,6 +4458,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-import-axfr-create",
@@ -4476,6 +4546,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-import-bind-create-create",
@@ -4573,6 +4645,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-import-bind-validate-create",
@@ -4662,6 +4736,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-import-create",
@@ -4748,6 +4824,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-local-zone-file-list",
@@ -4854,6 +4932,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-metric-create",
@@ -4954,6 +5034,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-pool-members-health-statu-list",
@@ -5048,6 +5130,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-record-name-delete",
@@ -5173,6 +5257,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-record-name-list",
@@ -5294,6 +5380,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-record-name-update",
@@ -5429,6 +5517,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-remote-zone-file-list",
@@ -5535,6 +5625,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-request-log-create",
@@ -5635,6 +5727,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-rrset-create",
@@ -5760,6 +5854,8 @@ export const dnsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-subscribe-create",
@@ -5846,6 +5942,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-suggest-value-create",
@@ -5933,6 +6031,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-unsubscribe-create",
@@ -6019,6 +6119,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-dns-verify-create",
@@ -6131,6 +6233,8 @@ export const dnsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/generative_ai/index.ts
+++ b/src/tools/generated/generative_ai/index.ts
@@ -91,6 +91,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-deallocateip-delete",
@@ -177,6 +179,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-enable-feature-create",
@@ -263,6 +267,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: true,
+    deprecationMessage: "Use Subscribe API",
   },
   {
     toolName: "f5xc-api-generativeai-eval-query-create",
@@ -362,6 +368,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-eval-query-feedback-create",
@@ -464,6 +472,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-gettoken-create",
@@ -557,6 +567,8 @@ export const generative_aiTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-query-create",
@@ -655,6 +667,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-query-feedback-create",
@@ -753,6 +767,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-refresh-token-create",
@@ -846,6 +862,8 @@ export const generative_aiTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-subscribe-create",
@@ -932,6 +950,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-generativeai-unsubscribe-create",
@@ -1018,6 +1038,8 @@ export const generative_aiTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/managed_kubernetes/index.ts
+++ b/src/tools/generated/managed_kubernetes/index.ts
@@ -138,6 +138,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-container-registry-delete",
@@ -263,6 +265,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-container-registry-get",
@@ -398,6 +402,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-container-registry-list",
@@ -539,6 +545,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-container-registry-update",
@@ -681,6 +689,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-binding-create",
@@ -816,6 +826,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-binding-delete",
@@ -942,6 +954,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-binding-get",
@@ -1079,6 +1093,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-binding-list",
@@ -1221,6 +1237,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-binding-update",
@@ -1365,6 +1383,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-create",
@@ -1500,6 +1520,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-delete",
@@ -1626,6 +1648,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-get",
@@ -1763,6 +1787,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-list",
@@ -1905,6 +1931,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-cluster-role-update",
@@ -2049,6 +2077,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-admission-create",
@@ -2183,6 +2213,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-admission-delete",
@@ -2309,6 +2341,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-admission-get",
@@ -2445,6 +2479,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-admission-list",
@@ -2587,6 +2623,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-admission-update",
@@ -2731,6 +2769,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-policy-create",
@@ -2865,6 +2905,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-policy-delete",
@@ -2990,6 +3032,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-policy-get",
@@ -3126,6 +3170,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-policy-list",
@@ -3267,6 +3313,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-managedkubernetes-k8s-pod-security-policy-update",
@@ -3410,6 +3458,8 @@ export const managed_kubernetesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/marketplace/index.ts
+++ b/src/tools/generated/marketplace/index.ts
@@ -100,6 +100,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-addon-service-get",
@@ -194,6 +196,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-addon-service-list",
@@ -328,6 +332,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-addon-subscription-create",
@@ -454,6 +460,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-addon-subscription-delete",
@@ -572,6 +580,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-addon-subscription-get",
@@ -700,6 +710,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-addon-subscription-list",
@@ -834,6 +846,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-addon-subscription-update",
@@ -969,6 +983,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-all-activation-statu-list",
@@ -1064,6 +1080,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-cminstance-create",
@@ -1188,6 +1206,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-cminstance-delete",
@@ -1307,6 +1327,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-cminstance-get",
@@ -1436,6 +1458,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-cminstance-list",
@@ -1571,6 +1595,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-cminstance-update",
@@ -1708,6 +1734,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-external-connector-create",
@@ -1835,6 +1863,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-external-connector-delete",
@@ -1954,6 +1984,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-external-connector-get",
@@ -2083,6 +2115,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-external-connector-list",
@@ -2218,6 +2252,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-external-connector-update",
@@ -2354,6 +2390,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-force-delete-create",
@@ -2499,6 +2537,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-generate-token-get",
@@ -2613,6 +2653,8 @@ export const marketplaceTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-get-security-config-create",
@@ -2723,6 +2765,8 @@ export const marketplaceTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-navigation-tile-get",
@@ -2850,6 +2894,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-navigation-tile-list",
@@ -2984,6 +3030,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-plan-get",
@@ -3110,6 +3158,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-plan-list",
@@ -3244,6 +3294,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-register-create",
@@ -3330,6 +3382,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-registration-detail-list",
@@ -3427,6 +3481,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-run-create",
@@ -3565,6 +3621,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-send-email-create",
@@ -3652,6 +3710,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-signup-create",
@@ -3738,6 +3798,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-statu-list",
@@ -3857,6 +3919,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-third-party-application-get",
@@ -3985,6 +4049,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-third-party-application-list",
@@ -4120,6 +4186,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-third-party-application-update",
@@ -4256,6 +4324,8 @@ export const marketplaceTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-marketplace-view-kind-list",
@@ -4375,6 +4445,8 @@ export const marketplaceTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/network/index.ts
+++ b/src/tools/generated/network/index.ts
@@ -133,6 +133,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-address-allocator-delete",
@@ -252,6 +254,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-address-allocator-get",
@@ -380,6 +384,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-address-allocator-list",
@@ -515,6 +521,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-advertise-policy-create",
@@ -642,6 +650,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-advertise-policy-delete",
@@ -760,6 +770,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-advertise-policy-get",
@@ -889,6 +901,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-advertise-policy-list",
@@ -1023,6 +1037,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-advertise-policy-update",
@@ -1159,6 +1175,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-asn-set-create",
@@ -1284,6 +1302,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-asn-set-delete",
@@ -1403,6 +1423,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-asn-set-get",
@@ -1533,6 +1555,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-asn-set-list",
@@ -1668,6 +1692,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-asn-set-update",
@@ -1805,6 +1831,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-create",
@@ -1930,6 +1958,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-delete",
@@ -2049,6 +2079,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-get",
@@ -2179,6 +2211,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-list",
@@ -2314,6 +2348,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-peer-list",
@@ -2420,6 +2456,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-route-list",
@@ -2526,6 +2564,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-routing-policy-create",
@@ -2653,6 +2693,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-routing-policy-delete",
@@ -2771,6 +2813,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-routing-policy-get",
@@ -2899,6 +2943,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-routing-policy-list",
@@ -3033,6 +3079,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-routing-policy-update",
@@ -3169,6 +3217,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgp-update",
@@ -3306,6 +3356,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-bgpstatu-list",
@@ -3425,6 +3477,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-dc-cluster-group-create",
@@ -3552,6 +3606,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-dc-cluster-group-delete",
@@ -3671,6 +3727,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-dc-cluster-group-get",
@@ -3800,6 +3858,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-dc-cluster-group-list",
@@ -3935,6 +3995,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-dc-cluster-group-update",
@@ -4071,6 +4133,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-forwarding-class-create",
@@ -4197,6 +4261,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-forwarding-class-delete",
@@ -4315,6 +4381,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-forwarding-class-get",
@@ -4443,6 +4511,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-forwarding-class-list",
@@ -4577,6 +4647,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-forwarding-class-update",
@@ -4712,6 +4784,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase1-profile-create",
@@ -4839,6 +4913,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase1-profile-delete",
@@ -4958,6 +5034,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase1-profile-get",
@@ -5087,6 +5165,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase1-profile-list",
@@ -5222,6 +5302,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase1-profile-update",
@@ -5358,6 +5440,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase2-profile-create",
@@ -5485,6 +5569,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase2-profile-delete",
@@ -5604,6 +5690,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase2-profile-get",
@@ -5733,6 +5821,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase2-profile-list",
@@ -5868,6 +5958,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike-phase2-profile-update",
@@ -6004,6 +6096,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike1-create",
@@ -6128,6 +6222,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike1-delete",
@@ -6247,6 +6343,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike1-get",
@@ -6376,6 +6474,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike1-list",
@@ -6511,6 +6611,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike1-update",
@@ -6647,6 +6749,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike2-create",
@@ -6771,6 +6875,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike2-delete",
@@ -6890,6 +6996,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike2-get",
@@ -7019,6 +7127,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike2-list",
@@ -7154,6 +7264,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ike2-update",
@@ -7290,6 +7402,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ip-prefix-set-create",
@@ -7415,6 +7529,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ip-prefix-set-delete",
@@ -7534,6 +7650,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ip-prefix-set-get",
@@ -7664,6 +7782,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ip-prefix-set-list",
@@ -7799,6 +7919,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-ip-prefix-set-update",
@@ -7936,6 +8058,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-metric-create",
@@ -8044,6 +8168,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-network-connector-create",
@@ -8171,6 +8297,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-network-connector-delete",
@@ -8290,6 +8418,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-network-connector-get",
@@ -8419,6 +8549,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-network-connector-list",
@@ -8554,6 +8686,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-network-connector-update",
@@ -8690,6 +8824,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-public-ip-get",
@@ -8819,6 +8955,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-public-ip-list",
@@ -8954,6 +9092,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-public-ip-update",
@@ -9091,6 +9231,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-route-create",
@@ -9216,6 +9358,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-route-delete",
@@ -9335,6 +9479,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-route-get",
@@ -9465,6 +9611,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-route-list",
@@ -9600,6 +9748,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-route-update",
@@ -9737,6 +9887,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-simplified-route-create",
@@ -9871,6 +10023,8 @@ export const networkTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-srv6-network-slice-create",
@@ -9999,6 +10153,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-srv6-network-slice-delete",
@@ -10118,6 +10274,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-srv6-network-slice-get",
@@ -10248,6 +10406,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-srv6-network-slice-list",
@@ -10383,6 +10543,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-srv6-network-slice-update",
@@ -10520,6 +10682,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-subnet-create",
@@ -10645,6 +10809,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-subnet-delete",
@@ -10764,6 +10930,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-subnet-get",
@@ -10893,6 +11061,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-subnet-list",
@@ -11028,6 +11198,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-subnet-update",
@@ -11164,6 +11336,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-traceroute-create",
@@ -11276,6 +11450,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-tunnel-create",
@@ -11407,6 +11583,8 @@ export const networkTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-tunnel-delete",
@@ -11533,6 +11711,8 @@ export const networkTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-tunnel-get",
@@ -11669,6 +11849,8 @@ export const networkTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-tunnel-list",
@@ -11811,6 +11993,8 @@ export const networkTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-tunnel-update",
@@ -11954,6 +12138,8 @@ export const networkTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-virtual-network-create",
@@ -12078,6 +12264,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-virtual-network-delete",
@@ -12197,6 +12385,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-virtual-network-get",
@@ -12326,6 +12516,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-virtual-network-list",
@@ -12461,6 +12653,8 @@ export const networkTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-network-virtual-network-update",
@@ -12597,6 +12791,8 @@ export const networkTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/network_security/index.ts
+++ b/src/tools/generated/network_security/index.ts
@@ -143,6 +143,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-delete",
@@ -275,6 +277,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-get",
@@ -417,6 +421,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-list",
@@ -565,6 +571,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-rule-create",
@@ -703,6 +711,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-rule-delete",
@@ -835,6 +845,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-rule-get",
@@ -977,6 +989,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-rule-list",
@@ -1125,6 +1139,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-rule-update",
@@ -1275,6 +1291,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-fast-acl-update",
@@ -1425,6 +1443,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-filter-set-create",
@@ -1562,6 +1582,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-filter-set-delete",
@@ -1694,6 +1716,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-filter-set-get",
@@ -1836,6 +1860,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-filter-set-list",
@@ -1984,6 +2010,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-filter-set-update",
@@ -2133,6 +2161,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-find-create",
@@ -2246,6 +2276,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-forward-proxy-policy-create",
@@ -2385,6 +2417,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-forward-proxy-policy-delete",
@@ -2516,6 +2550,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-forward-proxy-policy-get",
@@ -2657,6 +2693,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-forward-proxy-policy-list",
@@ -2804,6 +2842,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-forward-proxy-policy-update",
@@ -2952,6 +2992,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-graph-create",
@@ -3066,6 +3108,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-hit-create",
@@ -3179,6 +3223,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-latency-create",
@@ -3291,6 +3337,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-nat-policy-create",
@@ -3427,6 +3475,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-nat-policy-delete",
@@ -3558,6 +3608,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-nat-policy-get",
@@ -3700,6 +3752,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-nat-policy-list",
@@ -3847,6 +3901,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-nat-policy-update",
@@ -3996,6 +4052,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-firewall-create",
@@ -4136,6 +4194,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-firewall-delete",
@@ -4268,6 +4328,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-firewall-get",
@@ -4410,6 +4472,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-firewall-list",
@@ -4558,6 +4622,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-firewall-update",
@@ -4707,6 +4773,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-create",
@@ -4843,6 +4911,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-delete",
@@ -4974,6 +5044,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-get",
@@ -5115,6 +5187,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-list",
@@ -5262,6 +5336,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-rule-create",
@@ -5402,6 +5478,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-rule-delete",
@@ -5534,6 +5612,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-rule-get",
@@ -5676,6 +5756,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-rule-list",
@@ -5824,6 +5906,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-rule-update",
@@ -5974,6 +6058,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-set-get",
@@ -6114,6 +6200,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-set-list",
@@ -6262,6 +6350,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-update",
@@ -6411,6 +6501,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-view-create",
@@ -6551,6 +6643,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-view-delete",
@@ -6683,6 +6777,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-view-get",
@@ -6825,6 +6921,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-view-list",
@@ -6973,6 +7071,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-network-policy-view-update",
@@ -7122,6 +7222,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-policy-based-routing-create",
@@ -7262,6 +7364,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-policy-based-routing-delete",
@@ -7394,6 +7498,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-policy-based-routing-get",
@@ -7536,6 +7642,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-policy-based-routing-list",
@@ -7684,6 +7792,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-policy-based-routing-update",
@@ -7833,6 +7943,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-connection-get",
@@ -7974,6 +8086,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-connection-list",
@@ -8122,6 +8236,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-connection-update",
@@ -8271,6 +8387,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-create",
@@ -8408,6 +8526,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-delete",
@@ -8540,6 +8660,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-get",
@@ -8682,6 +8804,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-list",
@@ -8830,6 +8954,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-segment-update",
@@ -8979,6 +9105,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-service-policy-create",
@@ -9128,6 +9256,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-service-policy-delete",
@@ -9271,6 +9401,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-service-policy-get",
@@ -9425,6 +9557,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-service-policy-list",
@@ -9584,6 +9718,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-networksecurity-service-policy-update",
@@ -9745,6 +9881,8 @@ export const network_securityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/nginx_one/index.ts
+++ b/src/tools/generated/nginx_one/index.ts
@@ -131,6 +131,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-csg-list",
@@ -266,6 +268,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-dataplane-server-create",
@@ -369,6 +373,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-instance-get",
@@ -495,6 +501,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-instance-list",
@@ -630,6 +638,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-server-get",
@@ -757,6 +767,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-server-list",
@@ -892,6 +904,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-service-discovery-create",
@@ -1019,6 +1033,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-service-discovery-delete",
@@ -1137,6 +1153,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-service-discovery-get",
@@ -1266,6 +1284,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-service-discovery-list",
@@ -1400,6 +1420,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-nginx-service-discovery-update",
@@ -1536,6 +1558,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-subscribe-create",
@@ -1622,6 +1646,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-nginxone-unsubscribe-create",
@@ -1708,6 +1734,8 @@ export const nginx_oneTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/object_storage/index.ts
+++ b/src/tools/generated/object_storage/index.ts
@@ -150,6 +150,8 @@ export const object_storageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-objectstorage-mobile-integrator-list",
@@ -295,6 +297,8 @@ export const object_storageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-objectstorage-name-delete",
@@ -446,6 +450,8 @@ export const object_storageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-objectstorage-name-get",
@@ -579,6 +585,8 @@ export const object_storageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-objectstorage-object-type-delete",
@@ -729,6 +737,8 @@ export const object_storageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-objectstorage-object-type-update",
@@ -865,6 +875,8 @@ export const object_storageTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-objectstorage-stored-object-list",
@@ -1009,6 +1021,8 @@ export const object_storageTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/observability/index.ts
+++ b/src/tools/generated/observability/index.ts
@@ -106,6 +106,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-aggregation-create",
@@ -207,6 +209,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-alert-list",
@@ -370,6 +374,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-all-ns-alert-list",
@@ -533,6 +539,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-audit-log-create",
@@ -634,6 +642,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-certificate-report-detail-list",
@@ -729,6 +739,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-certificate-summary-list",
@@ -838,6 +850,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-dns-monitor-summary-list",
@@ -969,6 +983,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-dns-monitors-health-create",
@@ -1072,6 +1088,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-filtered-dns-monitor-list-list",
@@ -1216,6 +1234,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-filtered-http-monitor-list-list",
@@ -1360,6 +1380,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-firewall-log-create",
@@ -1461,6 +1483,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-global-history-list",
@@ -1604,6 +1628,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-global-summary-list",
@@ -1712,6 +1738,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-health-list",
@@ -1806,6 +1834,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-history-list",
@@ -1942,6 +1972,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-http-monitor-detail-list",
@@ -2073,6 +2105,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-http-monitor-summary-list",
@@ -2204,6 +2238,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-http-monitors-health-create",
@@ -2307,6 +2343,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-metric-query-create",
@@ -2407,6 +2445,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-monitor-event-list",
@@ -2550,6 +2590,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-monitor-history-list",
@@ -2705,6 +2747,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-platform-event-create",
@@ -2806,6 +2850,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-record-type-summary-list",
@@ -2900,6 +2946,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-scroll-create",
@@ -3000,6 +3048,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-scroll-list",
@@ -3109,6 +3159,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-source-summary-list",
@@ -3241,6 +3293,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-subscribe-create",
@@ -3333,6 +3387,8 @@ export const observabilityTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-suggest-value-create",
@@ -3434,6 +3490,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-tls-report-detail-list",
@@ -3541,6 +3599,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-tls-report-summary-list",
@@ -3648,6 +3708,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-tls-summary-list",
@@ -3742,6 +3804,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-unsubscribe-create",
@@ -3834,6 +3898,8 @@ export const observabilityTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-dns-monitor-create",
@@ -3957,6 +4023,8 @@ export const observabilityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-dns-monitor-delete",
@@ -4075,6 +4143,8 @@ export const observabilityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-dns-monitor-get",
@@ -4203,6 +4273,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-dns-monitor-list",
@@ -4337,6 +4409,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-dns-monitor-update",
@@ -4472,6 +4546,8 @@ export const observabilityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-http-monitor-create",
@@ -4595,6 +4671,8 @@ export const observabilityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-http-monitor-delete",
@@ -4713,6 +4791,8 @@ export const observabilityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-http-monitor-get",
@@ -4841,6 +4921,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-http-monitor-list",
@@ -4975,6 +5057,8 @@ export const observabilityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-v1-http-monitor-update",
@@ -5110,6 +5194,8 @@ export const observabilityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-vk8s-audit-log-create",
@@ -5218,6 +5304,8 @@ export const observabilityTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-observability-vk8s-event-create",
@@ -5326,6 +5414,8 @@ export const observabilityTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/rate_limiting/index.ts
+++ b/src/tools/generated/rate_limiting/index.ts
@@ -142,6 +142,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-policer-delete",
@@ -274,6 +276,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-policer-get",
@@ -416,6 +420,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-policer-list",
@@ -564,6 +570,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-policer-update",
@@ -713,6 +721,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-protocol-policer-create",
@@ -854,6 +864,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-protocol-policer-delete",
@@ -986,6 +998,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-protocol-policer-get",
@@ -1129,6 +1143,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-protocol-policer-list",
@@ -1277,6 +1293,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-protocol-policer-update",
@@ -1427,6 +1445,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-rate-limiter-create",
@@ -1565,6 +1585,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-rate-limiter-delete",
@@ -1697,6 +1719,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-rate-limiter-get",
@@ -1840,6 +1864,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-rate-limiter-list",
@@ -1988,6 +2014,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-ratelimiting-rate-limiter-update",
@@ -2138,6 +2166,8 @@ export const rate_limitingTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/secops_and_incident_response/index.ts
+++ b/src/tools/generated/secops_and_incident_response/index.ts
@@ -146,6 +146,8 @@ export const secops_and_incident_responseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-secopsandincidentresponse-malicious-user-mitigation-delete",
@@ -278,6 +280,8 @@ export const secops_and_incident_responseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-secopsandincidentresponse-malicious-user-mitigation-get",
@@ -421,6 +425,8 @@ export const secops_and_incident_responseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-secopsandincidentresponse-malicious-user-mitigation-list",
@@ -569,6 +575,8 @@ export const secops_and_incident_responseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-secopsandincidentresponse-malicious-user-mitigation-update",
@@ -719,6 +727,8 @@ export const secops_and_incident_responseTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/service_mesh/index.ts
+++ b/src/tools/generated/service_mesh/index.ts
@@ -154,6 +154,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-api-endpoint-list",
@@ -289,6 +291,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-setting-create",
@@ -426,6 +430,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-setting-delete",
@@ -558,6 +564,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-setting-get",
@@ -701,6 +709,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-setting-list",
@@ -849,6 +859,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-setting-update",
@@ -999,6 +1011,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-type-create",
@@ -1136,6 +1150,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-type-delete",
@@ -1268,6 +1284,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-type-get",
@@ -1410,6 +1428,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-type-list",
@@ -1558,6 +1578,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-app-type-update",
@@ -1708,6 +1730,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-endpoint-create",
@@ -1846,6 +1870,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-endpoint-delete",
@@ -1978,6 +2004,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-endpoint-get",
@@ -2121,6 +2149,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-endpoint-list",
@@ -2269,6 +2299,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-endpoint-update",
@@ -2419,6 +2451,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-force-delete-create",
@@ -2532,6 +2566,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-learnt-schema-create",
@@ -2663,6 +2699,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-metric-create",
@@ -2784,6 +2822,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-nfv-service-create",
@@ -2921,6 +2961,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-nfv-service-delete",
@@ -3053,6 +3095,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-nfv-service-get",
@@ -3195,6 +3239,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-nfv-service-list",
@@ -3343,6 +3389,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-nfv-service-update",
@@ -3492,6 +3540,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-override-list",
@@ -3611,6 +3661,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-pdf-create",
@@ -3760,6 +3812,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-pdf-list",
@@ -3904,6 +3958,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-pop-create",
@@ -4035,6 +4091,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-push-create",
@@ -4166,6 +4224,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-sid-counter-create",
@@ -4287,6 +4347,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-site-mesh-group-create",
@@ -4430,6 +4492,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-site-mesh-group-delete",
@@ -4568,6 +4632,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-site-mesh-group-get",
@@ -4716,6 +4782,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-site-mesh-group-list",
@@ -4870,6 +4938,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-site-mesh-group-update",
@@ -5025,6 +5095,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-software-os-version-create",
@@ -5127,6 +5199,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-suspicious-user-get",
@@ -5301,6 +5375,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-swagger-spec-list",
@@ -5420,6 +5496,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-virtual-network-create",
@@ -5557,6 +5635,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-virtual-network-delete",
@@ -5689,6 +5769,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-virtual-network-get",
@@ -5831,6 +5913,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-virtual-network-list",
@@ -5979,6 +6063,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-servicemesh-virtual-network-update",
@@ -6128,6 +6214,8 @@ export const service_meshTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/shape/index.ts
+++ b/src/tools/generated/shape/index.ts
@@ -105,6 +105,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-affecteduser-create",
@@ -217,6 +219,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-age-create",
@@ -303,6 +307,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-gen-policy-create",
@@ -429,6 +435,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-gen-policy-delete",
@@ -547,6 +555,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-gen-policy-get",
@@ -675,6 +685,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-gen-policy-list",
@@ -809,6 +821,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-gen-policy-update",
@@ -944,6 +958,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-template-create",
@@ -1067,6 +1083,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-template-delete",
@@ -1185,6 +1203,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-template-get",
@@ -1312,6 +1332,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-alert-template-list",
@@ -1446,6 +1468,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-allowed-domain-create",
@@ -1569,6 +1593,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-allowed-domain-delete",
@@ -1687,6 +1713,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-allowed-domain-get",
@@ -1814,6 +1842,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-allowed-domain-list",
@@ -1948,6 +1978,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-analysi-create",
@@ -2048,6 +2080,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-apikey-list",
@@ -2128,6 +2162,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-app-create",
@@ -2227,6 +2263,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-app-provision-create",
@@ -2313,6 +2351,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-application-create",
@@ -2399,6 +2439,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-application-delete",
@@ -2497,6 +2539,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-application-list",
@@ -2577,6 +2621,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-asn-create",
@@ -2677,6 +2723,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-asorg-create",
@@ -2776,6 +2824,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-atb-create",
@@ -2883,6 +2933,8 @@ export const shapeTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-atb-list",
@@ -2991,6 +3043,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-attackintent-create",
@@ -3091,6 +3145,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-audit-list",
@@ -3222,6 +3278,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-automation-create",
@@ -3321,6 +3379,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bad-bot-reduction-create",
@@ -3422,6 +3482,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-behavior-get",
@@ -3570,6 +3632,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bfp-create",
@@ -3669,6 +3733,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-allowlist-policie-list",
@@ -3764,6 +3830,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-allowlist-policy-get",
@@ -3891,6 +3959,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-allowlist-policy-list",
@@ -4025,6 +4095,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-allowlist-policy-update",
@@ -4152,6 +4224,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-detection-rule-create",
@@ -4254,6 +4328,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-detection-rule-get",
@@ -4379,6 +4455,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-detection-rule-list",
@@ -4513,6 +4591,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-detection-update-list",
@@ -4608,6 +4688,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-endpoint-policie-list",
@@ -4703,6 +4785,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-endpoint-policy-get",
@@ -4830,6 +4914,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-endpoint-policy-list",
@@ -4964,6 +5050,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-endpoint-policy-update",
@@ -5091,6 +5179,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-infrastructure-create",
@@ -5217,6 +5307,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-infrastructure-get",
@@ -5345,6 +5437,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-infrastructure-list",
@@ -5479,6 +5573,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-infrastructure-update",
@@ -5614,6 +5710,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-network-policie-list",
@@ -5709,6 +5807,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-network-policy-get",
@@ -5836,6 +5936,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-network-policy-list",
@@ -5970,6 +6072,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-bot-network-policy-update",
@@ -6097,6 +6201,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-browser-create",
@@ -6197,6 +6303,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-categorie-create",
@@ -6296,6 +6404,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-channel-create",
@@ -6382,6 +6492,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-check-create",
@@ -6468,6 +6580,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-clone-create",
@@ -6575,6 +6689,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-config-get",
@@ -6681,6 +6797,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-conversion-create",
@@ -6767,6 +6885,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-country-create",
@@ -6853,6 +6973,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-credential-stuffing-attack-create",
@@ -6954,6 +7076,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-dashboard-get",
@@ -7102,6 +7226,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-deployment-history-get",
@@ -7208,6 +7334,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-deployment-list",
@@ -7333,6 +7461,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-deployment-statu-get",
@@ -7440,6 +7570,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-detail-list",
@@ -7571,6 +7703,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-detected-domain-list",
@@ -7702,6 +7836,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-device-create",
@@ -7801,6 +7937,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-domain-detail-list",
@@ -7908,6 +8046,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-download-release-note-list",
@@ -8016,6 +8156,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-draft-create",
@@ -8115,6 +8257,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-draft-delete",
@@ -8214,6 +8358,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-draft-list",
@@ -8309,6 +8455,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-enable-create",
@@ -8395,6 +8543,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-endpoint-create",
@@ -8494,6 +8644,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-endpointlabel-create",
@@ -8593,6 +8745,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-enjoy-create",
@@ -8679,6 +8833,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-ep-create",
@@ -8779,6 +8935,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-expanded-create",
@@ -8878,6 +9036,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-feedback-create",
@@ -8978,6 +9138,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-field-create",
@@ -9079,6 +9241,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-formfield-create",
@@ -9179,6 +9343,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-formfield-get",
@@ -9285,6 +9451,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-formfield-list",
@@ -9407,6 +9575,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-friction-aggregation-create",
@@ -9496,6 +9666,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-friction-histogram-create",
@@ -9585,6 +9757,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-general-feedback-create",
@@ -9688,6 +9862,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-geolocation-create",
@@ -9787,6 +9963,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-getcurrentfrauddata-create",
@@ -9876,6 +10054,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-gettopriskyaccount-create",
@@ -9965,6 +10145,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-gettopriskydevice-create",
@@ -10054,6 +10236,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-gettopriskyipaddresse-create",
@@ -10143,6 +10327,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-gettopriskyreason-create",
@@ -10232,6 +10418,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-gettransactiondata-create",
@@ -10321,6 +10509,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-good-create",
@@ -10420,6 +10610,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-health-list",
@@ -10500,6 +10692,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-history-get",
@@ -10607,6 +10801,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-init-create",
@@ -10693,6 +10889,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: true,
+    deprecationMessage: "Use Subscribe API",
   },
   {
     toolName: "f5xc-api-shape-ip-create",
@@ -10793,6 +10991,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-js-configuration-list",
@@ -10900,6 +11100,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-justification-create",
@@ -11012,6 +11214,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-justification-delete",
@@ -11122,6 +11326,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-lift-create",
@@ -11208,6 +11414,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-list-create",
@@ -11307,6 +11515,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-metric-create",
@@ -11407,6 +11617,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mitigated-domain-create",
@@ -11533,6 +11745,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mitigated-domain-delete",
@@ -11651,6 +11865,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mitigated-domain-get",
@@ -11778,6 +11994,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mitigated-domain-list",
@@ -11912,6 +12130,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mobile-base-config-create",
@@ -12038,6 +12258,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mobile-base-config-delete",
@@ -12156,6 +12378,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mobile-base-config-file-get",
@@ -12264,6 +12488,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mobile-base-config-get",
@@ -12391,6 +12617,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mobile-base-config-list",
@@ -12525,6 +12753,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mobile-base-config-update",
@@ -12660,6 +12890,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-mobile-sdk-list",
@@ -12804,6 +13036,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-name-get",
@@ -12936,6 +13170,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-networkinteraction-get",
@@ -13071,6 +13307,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-o-create",
@@ -13171,6 +13409,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-overview-create",
@@ -13270,6 +13510,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-overview-list",
@@ -13403,6 +13645,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-personal-stat-create",
@@ -13501,6 +13745,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-platform-create",
@@ -13600,6 +13846,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-policie-create",
@@ -13713,6 +13961,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-application-create",
@@ -13839,6 +14089,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-application-delete",
@@ -13957,6 +14209,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-application-get",
@@ -14085,6 +14339,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-application-list",
@@ -14219,6 +14475,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-application-update",
@@ -14354,6 +14612,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-domain-create",
@@ -14480,6 +14740,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-domain-delete",
@@ -14598,6 +14860,8 @@ export const shapeTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-domain-get",
@@ -14725,6 +14989,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-protected-domain-list",
@@ -14859,6 +15125,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-provision-create",
@@ -14959,6 +15227,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-provision-list",
@@ -15039,6 +15309,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-readstatu-create",
@@ -15151,6 +15423,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-region-list",
@@ -15231,6 +15505,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-rescue-create",
@@ -15317,6 +15593,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-rule-create",
@@ -15417,6 +15695,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-safecubejsdata-create",
@@ -15503,6 +15783,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-script-create",
@@ -15603,6 +15885,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-script-list",
@@ -15764,6 +16048,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-session-create",
@@ -15850,6 +16136,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-src-tag-injection-create",
@@ -15939,6 +16227,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-state-list",
@@ -16019,6 +16309,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-statu-create",
@@ -16126,6 +16418,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-statu-list",
@@ -16220,6 +16514,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-subscribe-create",
@@ -16306,6 +16602,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-suggest-value-create",
@@ -16407,6 +16705,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-summary-create",
@@ -16506,6 +16806,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-summary-list",
@@ -16601,6 +16903,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-table-list",
@@ -16746,6 +17050,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-template-get",
@@ -16853,6 +17159,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-testj-create",
@@ -16953,6 +17261,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-threat-type-create",
@@ -17037,6 +17347,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-timeserie-create",
@@ -17136,6 +17448,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-top-good-bot-create",
@@ -17220,6 +17534,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-top-location-create",
@@ -17318,6 +17634,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-top-location-list",
@@ -17464,6 +17782,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-top-reason-code-create",
@@ -17548,6 +17868,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-top-source-create",
@@ -17646,6 +17968,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-top-source-list",
@@ -17792,6 +18116,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-total-automation-create",
@@ -17893,6 +18219,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transaction-create",
@@ -17979,6 +18307,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transaction-detail-create",
@@ -18082,6 +18412,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transaction-detail-list",
@@ -18201,6 +18533,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transaction-device-history-create",
@@ -18304,6 +18638,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transaction-location-create",
@@ -18407,6 +18743,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transaction-related-session-create",
@@ -18510,6 +18848,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transaction-timeline-create",
@@ -18613,6 +18953,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transactions-csv-create",
@@ -18716,6 +19058,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-transactions-over-time-create",
@@ -18819,6 +19163,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-ua-create",
@@ -18919,6 +19265,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-unaddressed-automation-create",
@@ -19021,6 +19369,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-unique-create",
@@ -19107,6 +19457,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-unsubscribe-create",
@@ -19193,6 +19545,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-update-domain-create",
@@ -19299,6 +19653,8 @@ export const shapeTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-url-create",
@@ -19385,6 +19741,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-shape-version-get",
@@ -19492,6 +19850,8 @@ export const shapeTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/sites/index.ts
+++ b/src/tools/generated/sites/index.ts
@@ -113,6 +113,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-tgw-site-create",
@@ -244,6 +246,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-tgw-site-delete",
@@ -370,6 +374,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-tgw-site-get",
@@ -506,6 +512,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-tgw-site-list",
@@ -648,6 +656,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-tgw-site-update",
@@ -791,6 +801,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-vpc-site-create",
@@ -922,6 +934,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-vpc-site-delete",
@@ -1048,6 +1062,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-vpc-site-get",
@@ -1184,6 +1200,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-vpc-site-list",
@@ -1326,6 +1344,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-aws-vpc-site-update",
@@ -1469,6 +1489,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-azure-vnet-site-create",
@@ -1600,6 +1622,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-azure-vnet-site-delete",
@@ -1726,6 +1750,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-azure-vnet-site-get",
@@ -1862,6 +1888,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-azure-vnet-site-list",
@@ -2004,6 +2032,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-azure-vnet-site-update",
@@ -2147,6 +2177,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-configmap-list",
@@ -2261,6 +2293,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-cronjob-list",
@@ -2375,6 +2409,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-daemonset-list",
@@ -2489,6 +2525,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-dc-cluster-group-create",
@@ -2599,6 +2637,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-dc-cluster-group-list",
@@ -2686,6 +2726,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-deployment-list",
@@ -2800,6 +2842,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-edge-create",
@@ -2908,6 +2952,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-endpoint-list",
@@ -3022,6 +3068,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-firewall-log-create",
@@ -3130,6 +3178,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-gcp-vpc-site-create",
@@ -3261,6 +3311,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-gcp-vpc-site-delete",
@@ -3387,6 +3439,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-gcp-vpc-site-get",
@@ -3523,6 +3577,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-gcp-vpc-site-list",
@@ -3665,6 +3721,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-gcp-vpc-site-update",
@@ -3808,6 +3866,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-global-kubeconfig-create",
@@ -3904,6 +3964,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-global-kubeconfig-list",
@@ -4006,6 +4068,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-global-network-list",
@@ -4131,6 +4195,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-job-list",
@@ -4245,6 +4311,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-k8s-audit-log-create",
@@ -4365,6 +4433,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-k8s-cluster-create",
@@ -4497,6 +4567,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-k8s-cluster-delete",
@@ -4623,6 +4695,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-k8s-cluster-get",
@@ -4760,6 +4834,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-k8s-cluster-list",
@@ -4902,6 +4978,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-k8s-cluster-update",
@@ -5046,6 +5124,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-k8s-event-create",
@@ -5166,6 +5246,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-local-kubeconfig-create",
@@ -5288,6 +5370,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-local-kubeconfig-get",
@@ -5401,6 +5485,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-log-create",
@@ -5545,6 +5631,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-metric-create",
@@ -5662,6 +5750,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-namespace-list",
@@ -5763,6 +5853,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-network-get",
@@ -5864,6 +5956,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-node-create",
@@ -5972,6 +6066,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-node-list",
@@ -6073,6 +6169,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-persistentvolume-list",
@@ -6174,6 +6272,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-persistentvolumeclaim-list",
@@ -6287,6 +6387,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-platform-event-create",
@@ -6395,6 +6497,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-pod-list",
@@ -6508,6 +6612,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-replicaset-list",
@@ -6621,6 +6727,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-route-table-get",
@@ -6795,6 +6903,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-scroll-create",
@@ -6902,6 +7012,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-scroll-list",
@@ -7018,6 +7130,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-secret-list",
@@ -7131,6 +7245,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-create",
@@ -7262,6 +7378,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-delete",
@@ -7388,6 +7506,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-get",
@@ -7524,6 +7644,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-list",
@@ -7666,6 +7788,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-update",
@@ -7809,6 +7933,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-v2-create",
@@ -7943,6 +8069,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-v2-delete",
@@ -8069,6 +8197,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-v2-get",
@@ -8205,6 +8335,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-v2-list",
@@ -8347,6 +8479,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-securemesh-site-v2-update",
@@ -8490,6 +8624,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-segment-list",
@@ -8603,6 +8739,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-selectee-get",
@@ -8718,6 +8856,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-service-list",
@@ -8831,6 +8971,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-set-cloud-site-info-create",
@@ -8962,6 +9104,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-set-tgw-info-create",
@@ -9089,6 +9233,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-set-vip-info-create",
@@ -9208,6 +9354,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-set-vpc-ip-prefixe-create",
@@ -9330,6 +9478,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-set-vpc-k8s-hostname-create",
@@ -9452,6 +9602,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-set-vpn-tunnel-create",
@@ -9571,6 +9723,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-site-create",
@@ -9679,6 +9833,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-site-get",
@@ -9814,6 +9970,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-site-list",
@@ -9956,6 +10114,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-site-mesh-group-create",
@@ -10075,6 +10235,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-site-mesh-group-list",
@@ -10174,6 +10336,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-site-update",
@@ -10317,6 +10481,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-state-create",
@@ -10437,6 +10603,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-statefulset-list",
@@ -10550,6 +10718,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-statu-create",
@@ -10657,6 +10827,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-upgrade-o-create",
@@ -10776,6 +10948,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-upgrade-sw-create",
@@ -10895,6 +11069,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-validate-config-create",
@@ -11014,6 +11190,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-k8s-create",
@@ -11145,6 +11323,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-k8s-delete",
@@ -11270,6 +11450,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-k8s-get",
@@ -11406,6 +11588,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-k8s-list",
@@ -11547,6 +11731,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-k8s-update",
@@ -11690,6 +11876,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-site-create",
@@ -11821,6 +12009,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-site-delete",
@@ -11947,6 +12137,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-site-get",
@@ -12083,6 +12275,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-site-list",
@@ -12225,6 +12419,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-virtual-site-update",
@@ -12368,6 +12564,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-vk8s-audit-log-create",
@@ -12482,6 +12680,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-vk8s-event-create",
@@ -12596,6 +12796,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-voltstack-site-create",
@@ -12727,6 +12929,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-voltstack-site-delete",
@@ -12853,6 +13057,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-voltstack-site-get",
@@ -12989,6 +13195,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-voltstack-site-list",
@@ -13131,6 +13339,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-sites-voltstack-site-update",
@@ -13274,6 +13484,8 @@ export const sitesTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/statistics/index.ts
+++ b/src/tools/generated/statistics/index.ts
@@ -106,6 +106,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-policy-create",
@@ -229,6 +231,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-policy-delete",
@@ -347,6 +351,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-policy-get",
@@ -475,6 +481,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-policy-list",
@@ -609,6 +617,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-policy-update",
@@ -744,6 +754,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-receiver-create",
@@ -868,6 +880,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-receiver-delete",
@@ -987,6 +1001,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-receiver-get",
@@ -1116,6 +1132,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-receiver-list",
@@ -1251,6 +1269,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-alert-receiver-update",
@@ -1387,6 +1407,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-all-ns-alert-list",
@@ -1550,6 +1572,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-all-ns-service-create",
@@ -1634,6 +1658,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-by-application-create",
@@ -1746,6 +1772,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-by-mitigation-create",
@@ -1863,6 +1891,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-by-network-create",
@@ -1975,6 +2005,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-by-zone-create",
@@ -2087,6 +2119,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-catalog-update",
@@ -2187,6 +2221,8 @@ export const statisticsTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-confirm-create",
@@ -2300,6 +2336,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-create-http-load-balancer-create",
@@ -2417,6 +2455,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-create-tcp-load-balancer-create",
@@ -2534,6 +2574,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-dc-cluster-group-create",
@@ -2637,6 +2679,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-dc-cluster-group-list",
@@ -2717,6 +2761,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-disable-visibility-create",
@@ -2834,6 +2880,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-discovered-service-get",
@@ -2959,6 +3007,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-discovered-service-list",
@@ -3080,6 +3130,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-download-get",
@@ -3186,6 +3238,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-enable-visibility-create",
@@ -3303,6 +3357,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-event-count-create",
@@ -3416,6 +3472,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-firewall-log-create",
@@ -3517,6 +3575,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-flow-anomaly-get",
@@ -3643,6 +3703,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-flow-anomaly-list",
@@ -3777,6 +3839,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-generate-create",
@@ -3890,6 +3954,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-global-log-receiver-create",
@@ -4017,6 +4083,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-global-log-receiver-delete",
@@ -4136,6 +4204,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-global-log-receiver-get",
@@ -4265,6 +4335,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-global-log-receiver-list",
@@ -4400,6 +4472,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-global-log-receiver-update",
@@ -4536,6 +4610,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-list-reports-history-bot-defence-create",
@@ -4638,6 +4714,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-list-reports-history-create",
@@ -4740,6 +4818,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-list-reports-history-waap-create",
@@ -4842,6 +4922,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-log-receiver-create",
@@ -4966,6 +5048,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-log-receiver-delete",
@@ -5085,6 +5169,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-log-receiver-get",
@@ -5214,6 +5300,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-log-receiver-list",
@@ -5349,6 +5437,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-log-receiver-update",
@@ -5485,6 +5575,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-match-create",
@@ -5586,6 +5678,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-matching-flow-create",
@@ -5712,6 +5806,8 @@ export const statisticsTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-platform-event-create",
@@ -5813,6 +5909,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-report-config-create",
@@ -5937,6 +6035,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-report-config-delete",
@@ -6055,6 +6155,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-report-config-get",
@@ -6183,6 +6285,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-report-config-list",
@@ -6317,6 +6421,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-report-config-update",
@@ -6453,6 +6559,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-report-get",
@@ -6578,6 +6686,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-route-table-get",
@@ -6745,6 +6855,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-scroll-create",
@@ -6845,6 +6957,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-scroll-list",
@@ -6954,6 +7068,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-site-mesh-group-create",
@@ -7073,6 +7189,8 @@ export const statisticsTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-site-mesh-group-list",
@@ -7172,6 +7290,8 @@ export const statisticsTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-statu-create",
@@ -7272,6 +7392,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-subscribe-create",
@@ -7366,6 +7488,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-subscription-statu-list",
@@ -7446,6 +7570,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-suggest-value-create",
@@ -7547,6 +7673,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-test-create",
@@ -7660,6 +7788,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-top-talker-create",
@@ -7780,6 +7910,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-unsubscribe-create",
@@ -7874,6 +8006,8 @@ export const statisticsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-verify-create",
@@ -7988,6 +8122,8 @@ export const statisticsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-vk8s-audit-log-create",
@@ -8096,6 +8232,8 @@ export const statisticsTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-statistics-vk8s-event-create",
@@ -8204,6 +8342,8 @@ export const statisticsTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/support/index.ts
+++ b/src/tools/generated/support/index.ts
@@ -141,6 +141,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-change-password-create",
@@ -266,6 +268,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-check-debug-info-collection-list",
@@ -360,6 +364,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-close-create",
@@ -473,6 +479,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-comment-create",
@@ -594,6 +602,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-config-create",
@@ -730,6 +740,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-config-list",
@@ -848,6 +860,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-customer-support-create",
@@ -974,6 +988,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-customer-support-get",
@@ -1102,6 +1118,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-customer-support-list",
@@ -1237,6 +1255,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-delete-create",
@@ -1373,6 +1393,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-dhcp-lease-list",
@@ -1479,6 +1501,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-diagnosi-list",
@@ -1586,6 +1610,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-disconnect-create",
@@ -1722,6 +1748,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-download-debug-info-collection-list",
@@ -1816,6 +1844,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-escalate-create",
@@ -1929,6 +1959,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-exec-create",
@@ -2063,6 +2095,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-exec-log-list",
@@ -2195,6 +2229,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-exec-user-create",
@@ -2329,6 +2365,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-fetchdump-create",
@@ -2439,6 +2477,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-health-list",
@@ -2546,6 +2586,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-host-ping-create",
@@ -2682,6 +2724,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-info-list",
@@ -2800,6 +2844,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-jira-projects-issue-type-create",
@@ -2891,6 +2937,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-list-list",
@@ -3009,6 +3057,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-list-service-list",
@@ -3115,6 +3165,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-list-tcpdump-create",
@@ -3235,6 +3287,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-log-list",
@@ -3379,6 +3433,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-ping-create",
@@ -3491,6 +3547,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-priority-create",
@@ -3604,6 +3662,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-reboot-create",
@@ -3740,6 +3800,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-reopen-create",
@@ -3852,6 +3914,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-resync-crl-create",
@@ -3970,6 +4034,8 @@ export const supportTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-rule-list",
@@ -4088,6 +4154,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-soft-restart-create",
@@ -4238,6 +4306,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-start-debug-info-collection-list",
@@ -4343,6 +4413,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-statu-list",
@@ -4473,6 +4545,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-stop-tcpdump-create",
@@ -4583,6 +4657,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-support-ticket-create",
@@ -4670,6 +4746,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-tax-exempt-request-create",
@@ -4768,6 +4846,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-tcpdump-create",
@@ -4880,6 +4960,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-ticket-tracking-system-create",
@@ -5006,6 +5088,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-ticket-tracking-system-delete",
@@ -5124,6 +5208,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-ticket-tracking-system-get",
@@ -5251,6 +5337,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-ticket-tracking-system-list",
@@ -5385,6 +5473,8 @@ export const supportTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-ticket-tracking-system-update",
@@ -5520,6 +5610,8 @@ export const supportTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-support-validate-ticket-tracking-system-create",
@@ -5625,6 +5717,8 @@ export const supportTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/telemetry_and_insights/index.ts
+++ b/src/tools/generated/telemetry_and_insights/index.ts
@@ -89,6 +89,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-app-type-list",
@@ -212,6 +214,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-connectivity-create",
@@ -312,6 +316,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-create-http-load-balancer-create",
@@ -429,6 +435,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-create-tcp-load-balancer-create",
@@ -546,6 +554,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-disable-visibility-create",
@@ -663,6 +673,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-discovered-service-get",
@@ -788,6 +800,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-discovered-service-list",
@@ -909,6 +923,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-edge-create",
@@ -1010,6 +1026,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-enable-visibility-create",
@@ -1127,6 +1145,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-flow-collection-create",
@@ -1211,6 +1231,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-health-statu-get",
@@ -1318,6 +1340,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-instance-create",
@@ -1419,6 +1443,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-lb-cache-content-create",
@@ -1531,6 +1557,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-node-create",
@@ -1632,6 +1660,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-service-create",
@@ -1731,6 +1761,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-status-at-site-get",
@@ -1882,6 +1914,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-subscribe-create",
@@ -1976,6 +2010,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-subscription-statu-list",
@@ -2056,6 +2092,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-suggest-value-create",
@@ -2157,6 +2195,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-top-flow-anomalie-create",
@@ -2246,6 +2286,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-top-talker-create",
@@ -2330,6 +2372,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-telemetryandinsights-unsubscribe-create",
@@ -2424,6 +2468,8 @@ export const telemetry_and_insightsTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/tenant_and_identity/index.ts
+++ b/src/tools/generated/tenant_and_identity/index.ts
@@ -105,6 +105,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-acces-create",
@@ -193,6 +195,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-acces-list",
@@ -273,6 +277,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-active-alert-policie-create",
@@ -385,6 +391,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-active-alert-policie-list",
@@ -480,6 +488,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-active-network-policie-create",
@@ -592,6 +602,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-active-network-policie-list",
@@ -687,6 +699,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-active-service-policie-create",
@@ -799,6 +813,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-active-service-policie-list",
@@ -894,6 +910,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-admin-notification-list",
@@ -975,6 +993,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-admin-notification-update",
@@ -1060,6 +1080,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-admin-reset-create",
@@ -1147,6 +1169,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-admin-reset-update",
@@ -1231,6 +1255,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-all-application-inventory-create",
@@ -1371,6 +1397,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-all-application-inventory-waf-filter-create",
@@ -1488,6 +1516,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-all-ns-stat-create",
@@ -1575,6 +1605,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-allowed-tenant-create",
@@ -1699,6 +1731,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-allowed-tenant-delete",
@@ -1817,6 +1851,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-allowed-tenant-get",
@@ -1946,6 +1982,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-allowed-tenant-list",
@@ -2080,6 +2118,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-allowed-tenant-update",
@@ -2216,6 +2256,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-analyze-for-deletion-create",
@@ -2312,6 +2354,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-application-inventory-create",
@@ -2466,6 +2510,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-assign-create",
@@ -2553,6 +2599,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-assign-namespace-role-update",
@@ -2651,6 +2699,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-authentication-create",
@@ -2775,6 +2825,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-authentication-delete",
@@ -2894,6 +2946,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-authentication-get",
@@ -3023,6 +3077,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-authentication-list",
@@ -3158,6 +3214,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-authentication-update",
@@ -3294,6 +3352,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-cascade-delete-create",
@@ -3403,6 +3463,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-create",
@@ -3527,6 +3589,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-delete",
@@ -3645,6 +3709,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-get",
@@ -3739,6 +3805,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-list",
@@ -3874,6 +3942,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-manager-create",
@@ -4001,6 +4071,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-manager-delete",
@@ -4119,6 +4191,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-manager-get",
@@ -4247,6 +4321,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-manager-list",
@@ -4381,6 +4457,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-manager-update",
@@ -4516,6 +4594,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-child-tenant-update",
@@ -4651,6 +4731,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-citie-list",
@@ -4773,6 +4855,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-close-create",
@@ -4872,6 +4956,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-combined-notification-list",
@@ -4953,6 +5039,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-combined-notification-update",
@@ -5038,6 +5126,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-comment-create",
@@ -5147,6 +5237,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-contact-create",
@@ -5271,6 +5363,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-contact-delete",
@@ -5389,6 +5483,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-contact-get",
@@ -5518,6 +5614,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-contact-list",
@@ -5652,6 +5750,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-contact-update",
@@ -5787,6 +5887,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-countrie-list",
@@ -5884,6 +5986,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-customer-support-create",
@@ -5995,6 +6099,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-customer-support-list",
@@ -6075,6 +6181,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-deactivate-update",
@@ -6162,6 +6270,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-delete-create",
@@ -6273,6 +6383,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-disable-update",
@@ -6358,6 +6470,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-enable-update",
@@ -6443,6 +6557,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-escalate-create",
@@ -6542,6 +6658,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-evaluate-api-acces-create",
@@ -6640,6 +6758,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-evaluate-batch-api-acces-create",
@@ -6730,6 +6850,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-fast-acls-for-internet-vip-create",
@@ -6842,6 +6964,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-fast-acls-for-internet-vip-list",
@@ -6937,6 +7061,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-favicon-list",
@@ -7017,6 +7143,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-add-update",
@@ -7101,6 +7229,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-create",
@@ -7187,6 +7317,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-delete",
@@ -7302,6 +7434,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-get",
@@ -7413,6 +7547,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-list",
@@ -7549,6 +7685,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-patch",
@@ -7649,6 +7787,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-remove-update",
@@ -7733,6 +7873,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-group-update",
@@ -7833,6 +7975,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-image-delete",
@@ -7917,6 +8061,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-image-list",
@@ -7997,6 +8143,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-image-update",
@@ -8083,6 +8231,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-inactive-list",
@@ -8164,6 +8314,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-last-login-list",
@@ -8244,6 +8396,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-login-in-time-create",
@@ -8331,6 +8485,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-login-list",
@@ -8440,6 +8596,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-logo-list",
@@ -8520,6 +8678,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-lookup-list",
@@ -8627,6 +8787,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-lookup-user-role-create",
@@ -8716,6 +8878,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-managed-tenant-create",
@@ -8840,6 +9004,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-managed-tenant-delete",
@@ -8958,6 +9124,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-managed-tenant-get",
@@ -9087,6 +9255,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-managed-tenant-list",
@@ -9209,6 +9379,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-managed-tenant-update",
@@ -9345,6 +9517,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-managed-tenants-by-user-list",
@@ -9468,6 +9642,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-managed-tenants-list-list",
@@ -9590,6 +9766,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-mapper-create",
@@ -9701,6 +9879,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-mapper-get",
@@ -9808,6 +9988,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-migrate-create",
@@ -9915,6 +10097,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-namespace-create",
@@ -10023,6 +10207,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-namespace-get",
@@ -10151,6 +10337,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-namespace-list",
@@ -10284,6 +10472,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-namespace-role-get",
@@ -10410,6 +10600,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-namespace-role-list",
@@ -10544,6 +10736,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-namespace-update",
@@ -10667,6 +10861,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-networking-inventory-create",
@@ -10757,6 +10953,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-notification-list",
@@ -10838,6 +11036,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-notification-update",
@@ -10923,6 +11123,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-oidc-provider-create",
@@ -11039,6 +11241,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-oidc-provider-get",
@@ -11146,6 +11350,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-oidc-provider-list",
@@ -11241,6 +11447,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-oidc-provider-update",
@@ -11353,6 +11561,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-password-policy-list",
@@ -11447,6 +11657,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-priority-create",
@@ -11547,6 +11759,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-rbac-policy-get",
@@ -11674,6 +11888,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-rbac-policy-list",
@@ -11808,6 +12024,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-remove-namespace-role-update",
@@ -11906,6 +12124,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-reopen-create",
@@ -12004,6 +12224,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-request-delete-create",
@@ -12091,6 +12313,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-request-initial-acces-update",
@@ -12178,6 +12402,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-reset-create",
@@ -12262,6 +12488,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-resourcetype-get",
@@ -12373,6 +12601,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-resourcetype-list",
@@ -12453,6 +12683,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-role-create",
@@ -12575,6 +12807,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-role-delete",
@@ -12693,6 +12927,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-role-get",
@@ -12799,6 +13035,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-role-list",
@@ -12893,6 +13131,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-role-update",
@@ -13020,6 +13260,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-role-user-create",
@@ -13128,6 +13370,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-schema-get",
@@ -13239,6 +13483,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-schema-list",
@@ -13319,6 +13565,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-scim-update",
@@ -13431,6 +13679,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-send-password-email-create",
@@ -13535,6 +13785,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-serviceproviderconfig-list",
@@ -13615,6 +13867,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-session-list",
@@ -13695,6 +13949,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-setting-list",
@@ -13776,6 +14032,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-setting-update",
@@ -13871,6 +14129,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-signup-get",
@@ -13967,6 +14227,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-stat-create",
@@ -14075,6 +14337,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-state-list",
@@ -14185,6 +14449,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-subscribe-create",
@@ -14272,6 +14538,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-suggest-value-create",
@@ -14357,6 +14625,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-summary-list",
@@ -14448,6 +14718,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-support-info-list",
@@ -14528,6 +14800,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-sync-create",
@@ -14613,6 +14887,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-configuration-create",
@@ -14733,6 +15009,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-configuration-delete",
@@ -14852,6 +15130,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-configuration-get",
@@ -14981,6 +15261,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-configuration-list",
@@ -15116,6 +15398,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-configuration-update",
@@ -15245,6 +15529,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-escalation-doc-list",
@@ -15325,6 +15611,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-profile-create",
@@ -15449,6 +15737,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-profile-delete",
@@ -15567,6 +15857,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-profile-get",
@@ -15695,6 +15987,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-profile-list",
@@ -15829,6 +16123,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-tenant-profile-update",
@@ -15964,6 +16260,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-to-list",
@@ -16058,6 +16356,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-unassign-create",
@@ -16145,6 +16445,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-unset-update",
@@ -16230,6 +16532,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-unsubscribe-create",
@@ -16317,6 +16621,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-update-allow-advertise-on-public-create",
@@ -16406,6 +16712,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-create",
@@ -16500,6 +16808,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-delete",
@@ -16615,6 +16925,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-get",
@@ -16726,6 +17038,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-group-create",
@@ -16810,6 +17124,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-group-delete",
@@ -16922,6 +17238,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-group-get",
@@ -17017,6 +17335,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-group-list",
@@ -17097,6 +17417,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-group-update",
@@ -17196,6 +17518,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-identification-create",
@@ -17324,6 +17648,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-identification-delete",
@@ -17443,6 +17769,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-identification-get",
@@ -17573,6 +17901,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-identification-list",
@@ -17708,6 +18038,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-identification-update",
@@ -17845,6 +18177,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-list",
@@ -17981,6 +18315,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-patch",
@@ -18079,6 +18415,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-role-create",
@@ -18178,6 +18516,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-role-list",
@@ -18272,6 +18612,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-role-update",
@@ -18371,6 +18713,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-token-list",
@@ -18458,6 +18802,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-user-update",
@@ -18566,6 +18912,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-validate-contact-create",
@@ -18664,6 +19012,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-validate-registration-create",
@@ -18762,6 +19112,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-validate-rule-create",
@@ -18849,6 +19201,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-view-preference-list",
@@ -18929,6 +19283,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-view-preference-update",
@@ -19015,6 +19371,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-tenantandidentity-whoami-list",
@@ -19111,6 +19469,8 @@ export const tenant_and_identityTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/threat_campaign/index.ts
+++ b/src/tools/generated/threat_campaign/index.ts
@@ -99,6 +99,8 @@ export const threat_campaignTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/users/index.ts
+++ b/src/tools/generated/users/index.ts
@@ -114,6 +114,8 @@ export const usersTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-delete-create",
@@ -223,6 +225,8 @@ export const usersTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-get-cloud-init-config-list",
@@ -327,6 +331,8 @@ export const usersTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-implicit-label-list",
@@ -481,6 +487,8 @@ export const usersTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-known-label-key-list",
@@ -602,6 +610,8 @@ export const usersTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-known-label-list",
@@ -741,6 +751,8 @@ export const usersTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-state-create",
@@ -853,6 +865,8 @@ export const usersTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-token-create",
@@ -984,6 +998,8 @@ export const usersTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-token-delete",
@@ -1109,6 +1125,8 @@ export const usersTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-token-get",
@@ -1245,6 +1263,8 @@ export const usersTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-token-list",
@@ -1386,6 +1406,8 @@ export const usersTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-users-token-update",
@@ -1529,6 +1551,8 @@ export const usersTools: ParsedOperation[] = [
         tier: "standard",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/virtual/index.ts
+++ b/src/tools/generated/virtual/index.ts
@@ -118,6 +118,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: true,
+    deprecationMessage: "Use GetAPIEndpoints in virtual_host.ApiepCustomAPI",
   },
   {
     toolName: "f5xc-api-virtual-api-endpoint-get",
@@ -306,6 +308,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-assign-create",
@@ -427,6 +431,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: true,
+    deprecationMessage: "instead use virtual host public custom api - AssignAPIDefinition",
   },
   {
     toolName: "f5xc-api-virtual-available-get",
@@ -534,6 +540,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: true,
+    deprecationMessage: "instead use public crud api definition - GET List",
   },
   {
     toolName: "f5xc-api-virtual-ca-certificate-get",
@@ -640,6 +648,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-calls-by-response-code-create",
@@ -755,6 +765,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-cluster-create",
@@ -880,6 +892,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-cluster-delete",
@@ -999,6 +1013,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-cluster-get",
@@ -1129,6 +1145,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-cluster-list",
@@ -1264,6 +1282,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-cluster-update",
@@ -1401,6 +1421,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-create-ticket-create",
@@ -1511,6 +1533,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-dos-automitigation-rule-delete",
@@ -1634,6 +1658,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-dos-automitigation-rule-get",
@@ -1741,6 +1767,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-geo-location-set-create",
@@ -1867,6 +1895,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-geo-location-set-delete",
@@ -1985,6 +2015,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-geo-location-set-get",
@@ -2113,6 +2145,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-geo-location-set-list",
@@ -2247,6 +2281,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-geo-location-set-update",
@@ -2382,6 +2418,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-get-dns-info-get",
@@ -2488,6 +2526,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-get-schema-update-create",
@@ -2613,6 +2653,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: true,
+    deprecationMessage: "USE virtual host custom api GetAPIEndpointsSchemaUpdates",
   },
   {
     toolName: "f5xc-api-virtual-get-security-config-create",
@@ -2722,6 +2764,8 @@ export const virtualTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-healthcheck-create",
@@ -2847,6 +2891,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-healthcheck-delete",
@@ -2966,6 +3012,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-healthcheck-get",
@@ -3096,6 +3144,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-healthcheck-list",
@@ -3231,6 +3281,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-healthcheck-update",
@@ -3368,6 +3420,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-http-loadbalancer-create",
@@ -3495,6 +3549,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-http-loadbalancer-delete",
@@ -3614,6 +3670,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-http-loadbalancer-get",
@@ -3743,6 +3801,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-http-loadbalancer-list",
@@ -3878,6 +3938,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-http-loadbalancer-update",
@@ -4014,6 +4076,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-l7ddos-rps-threshold-create",
@@ -4129,6 +4193,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-learnt-schema-get",
@@ -4292,6 +4358,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-origin-pool-create",
@@ -4416,6 +4484,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-origin-pool-delete",
@@ -4535,6 +4605,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-origin-pool-get",
@@ -4663,6 +4735,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-origin-pool-list",
@@ -4798,6 +4872,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-origin-pool-update",
@@ -4934,6 +5010,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-pdf-get",
@@ -5066,6 +5144,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-proxy-create",
@@ -5189,6 +5269,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-proxy-delete",
@@ -5307,6 +5389,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-proxy-get",
@@ -5435,6 +5519,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-proxy-list",
@@ -5569,6 +5655,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-proxy-update",
@@ -5704,6 +5792,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-rate-limiter-policy-create",
@@ -5843,6 +5933,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-rate-limiter-policy-delete",
@@ -5974,6 +6066,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-rate-limiter-policy-get",
@@ -6115,6 +6209,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-rate-limiter-policy-list",
@@ -6262,6 +6358,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-rate-limiter-policy-update",
@@ -6410,6 +6508,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-create",
@@ -6547,6 +6647,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-delete",
@@ -6678,6 +6780,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-get",
@@ -6820,6 +6924,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-list",
@@ -6967,6 +7073,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-rule-create",
@@ -7108,6 +7216,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-rule-delete",
@@ -7240,6 +7350,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-rule-get",
@@ -7383,6 +7495,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-rule-list",
@@ -7531,6 +7645,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-rule-update",
@@ -7681,6 +7797,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-set-get",
@@ -7822,6 +7940,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-set-list",
@@ -7970,6 +8090,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-service-policy-update",
@@ -8119,6 +8241,8 @@ export const virtualTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-sources-openapi-schema-get",
@@ -8251,6 +8375,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-stat-get",
@@ -8357,6 +8483,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-subscribe-create",
@@ -8443,6 +8571,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-swagger-spec-get",
@@ -8549,6 +8679,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-tcp-loadbalancer-create",
@@ -8676,6 +8808,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-tcp-loadbalancer-delete",
@@ -8795,6 +8929,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-tcp-loadbalancer-get",
@@ -8924,6 +9060,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-tcp-loadbalancer-list",
@@ -9059,6 +9197,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-tcp-loadbalancer-update",
@@ -9195,6 +9335,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-top-active-create",
@@ -9316,6 +9458,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-top-sensitive-data-create",
@@ -9432,6 +9576,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-udp-loadbalancer-create",
@@ -9559,6 +9705,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-udp-loadbalancer-delete",
@@ -9678,6 +9826,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-udp-loadbalancer-get",
@@ -9807,6 +9957,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-udp-loadbalancer-list",
@@ -9942,6 +10094,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-udp-loadbalancer-update",
@@ -10078,6 +10232,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-unlink-ticket-create",
@@ -10195,6 +10351,8 @@ export const virtualTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-unmerge-sources-openapi-schema-create",
@@ -10308,6 +10466,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-unsubscribe-create",
@@ -10394,6 +10554,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-update-schema-create",
@@ -10507,6 +10669,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: true,
+    deprecationMessage: "USE virtual host custom api UpdateAPIEndpointsSchemas",
   },
   {
     toolName: "f5xc-api-virtual-update-state-create",
@@ -10625,6 +10789,8 @@ export const virtualTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-virtual-host-create",
@@ -10749,6 +10915,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-virtual-host-delete",
@@ -10868,6 +11036,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-virtual-host-get",
@@ -10997,6 +11167,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-virtual-host-list",
@@ -11132,6 +11304,8 @@ export const virtualTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-virtual-host-update",
@@ -11268,6 +11442,8 @@ export const virtualTools: ParsedOperation[] = [
     ],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-virtual-vulnerabilitie-create",
@@ -11386,6 +11562,8 @@ export const virtualTools: ParsedOperation[] = [
       },
     ],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/vpm_and_node_management/index.ts
+++ b/src/tools/generated/vpm_and_node_management/index.ts
@@ -85,6 +85,8 @@ export const vpm_and_node_managementTools: ParsedOperation[] = [
     dependencies: [],
     oneOfGroups: [],
     subscriptionRequirements: [],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/src/tools/generated/waf/index.ts
+++ b/src/tools/generated/waf/index.ts
@@ -125,6 +125,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-aggregation-create",
@@ -224,6 +226,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-all-ns-event-create",
@@ -323,6 +327,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-all-ns-metric-create",
@@ -420,6 +426,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-app-firewall-create",
@@ -557,6 +565,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-app-firewall-delete",
@@ -689,6 +699,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-app-firewall-get",
@@ -831,6 +843,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-app-firewall-list",
@@ -979,6 +993,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-app-firewall-update",
@@ -1128,6 +1144,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-enhanced-firewall-policy-create",
@@ -1267,6 +1285,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-enhanced-firewall-policy-delete",
@@ -1398,6 +1418,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-enhanced-firewall-policy-get",
@@ -1539,6 +1561,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-enhanced-firewall-policy-list",
@@ -1686,6 +1710,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-enhanced-firewall-policy-update",
@@ -1834,6 +1860,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-event-create",
@@ -1946,6 +1974,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-hit-create",
@@ -2060,6 +2090,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-incident-create",
@@ -2174,6 +2206,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-loadbalancer-create",
@@ -2272,6 +2306,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-metric-create",
@@ -2383,6 +2419,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-protocol-inspection-create",
@@ -2524,6 +2562,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-protocol-inspection-delete",
@@ -2656,6 +2696,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-protocol-inspection-get",
@@ -2798,6 +2840,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-protocol-inspection-list",
@@ -2946,6 +2990,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-protocol-inspection-update",
@@ -3095,6 +3141,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-released-signature-list",
@@ -3215,6 +3263,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-rule-hit-create",
@@ -3328,6 +3378,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-scroll-create",
@@ -3443,6 +3495,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-scroll-list",
@@ -3565,6 +3619,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-security-event-create",
@@ -3678,6 +3734,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-staged-signature-create",
@@ -3806,6 +3864,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-suspicious-user-log-create",
@@ -3923,6 +3983,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-waf-exclusion-policy-create",
@@ -4062,6 +4124,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-waf-exclusion-policy-delete",
@@ -4193,6 +4257,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-waf-exclusion-policy-get",
@@ -4334,6 +4400,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-waf-exclusion-policy-list",
@@ -4481,6 +4549,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
   {
     toolName: "f5xc-api-waf-waf-exclusion-policy-update",
@@ -4629,6 +4699,8 @@ export const wafTools: ParsedOperation[] = [
         tier: "advanced",
       },
     ],
+    isDeprecated: false,
+    deprecationMessage: null,
   },
 ];
 

--- a/tests/unit/discovery.test.ts
+++ b/tests/unit/discovery.test.ts
@@ -470,9 +470,17 @@ describe("Token Efficiency Validation", () => {
     const index = getToolIndex();
     const sampleEntry = index.tools[0];
 
-    // Each entry should only have 5 fields for minimal tokens
+    // Each entry should only have 7 fields for minimal tokens (Phase A added danger/deprecation)
     const fields = Object.keys(sampleEntry);
-    expect(fields).toEqual(["name", "domain", "resource", "operation", "summary"]);
+    expect(fields).toEqual([
+      "name",
+      "domain",
+      "resource",
+      "operation",
+      "summary",
+      "dangerLevel",
+      "isDeprecated",
+    ]);
   });
 
   it("should have significantly fewer tokens than full tools", () => {


### PR DESCRIPTION
## Summary
Surface underutilized OpenAPI metadata for richer tool discovery (Phase A of enhancement plan):

- Add deprecation extraction (`x-ves-deprecated`) to parser
- Add `dangerLevel` and `isDeprecated` to `ToolIndexEntry`
- Add `excludeDangerous`/`excludeDeprecated` search filters
- Surface oneOf groups in describe output
- Add common errors section to describe output
- Regenerate all 1548 tools with new fields

## New Capabilities

**Search Filters:**
- `excludeDangerous`: Filter out high-risk operations
- `excludeDeprecated`: Filter out deprecated operations

**Enhanced Describe Output:**
- `dangerLevel` (low/medium/high)
- `isDeprecated`, `deprecationMessage`
- `oneOfGroups` (mutually exclusive choices)
- `commonErrors` (anticipated API errors)

## Test plan
- [x] TypeScript compilation passes
- [x] All 1358 tests pass
- [x] ESLint clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)