### PR TITLE
fix: add --tag latest to npm publish for timestamp versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
Fix npm publish failing with "must specify tag for prerelease" error.

npm treats versions like `1.0.82-2512312022` as prereleases because of the hyphen.
Adding `--tag latest` ensures the package is published under the correct tag.

## Test plan
- [ ] CI workflow completes npm publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)