### PR TITLE
fix: disable no-undef ESLint rule for TypeScript files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,8 @@ export default [
       "@typescript-eslint": tseslint,
     },
     rules: {
+      // Disable no-undef for TypeScript (TypeScript handles this)
+      "no-undef": "off",
       // TypeScript rules
       "@typescript-eslint/explicit-function-return-type": "warn",
       "@typescript-eslint/no-unused-vars": [

--- a/src/auth/credential-manager.ts
+++ b/src/auth/credential-manager.ts
@@ -166,7 +166,11 @@ export class CredentialManager {
   /**
    * Load credentials from environment variables
    */
-  private loadFromEnvironment(): Partial<Profile> & { hasAuth: boolean; tlsInsecure: boolean; caBundle: string | undefined } {
+  private loadFromEnvironment(): Partial<Profile> & {
+    hasAuth: boolean;
+    tlsInsecure: boolean;
+    caBundle: string | undefined;
+  } {
     const apiUrl = process.env[AUTH_ENV_VARS.API_URL];
     const apiToken = process.env[AUTH_ENV_VARS.API_TOKEN];
     const p12Bundle = process.env[AUTH_ENV_VARS.P12_BUNDLE];
@@ -217,7 +221,9 @@ export class CredentialManager {
   /**
    * Build credentials object from profile data
    */
-  private buildCredentials(profile: Profile & { tlsInsecure?: boolean; caBundle?: string }): Credentials {
+  private buildCredentials(
+    profile: Profile & { tlsInsecure?: boolean; caBundle?: string }
+  ): Credentials {
     const apiUrl = profile.apiUrl;
 
     // Determine authentication mode

--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 /**
  * Error handling utilities for F5XC API MCP Server
  *
@@ -242,7 +243,7 @@ export function categorizeError(error: unknown): ErrorCategory {
       message.includes("ssl") ||
       message.includes("tls") ||
       message.includes("altnames") ||
-      message.includes("hostname") && message.includes("match") ||
+      (message.includes("hostname") && message.includes("match")) ||
       message.includes("self signed") ||
       message.includes("self-signed") ||
       message.includes("unable to verify") ||


### PR DESCRIPTION
## Summary
- Disable ESLint `no-undef` rule for TypeScript files
- TypeScript already handles undefined variable checking
- ESLint's `no-undef` doesn't understand TypeScript namespaces like `NodeJS`
- This fixes CI failures on `NodeJS.ErrnoException` usage in `error-handling.ts`

## Changes
- `eslint.config.js`: Added `"no-undef": "off"` for TypeScript files
- `src/utils/error-handling.ts`: Added `/// <reference types="node" />` (not required but good practice)

## Test plan
- [x] `npm run lint` passes with only warnings
- [x] All 1216 tests pass
- [x] TypeScript still catches actual undefined variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)