### PR TITLE
fix: correct URL normalization and API path handling

### DIFF
--- a/src/auth/credential-manager.ts
+++ b/src/auth/credential-manager.ts
@@ -69,9 +69,11 @@ export interface Credentials {
  * URL normalization patterns
  */
 const URL_PATTERNS = {
-  // Match short-form URLs: tenant.volterra.us or tenant.staging.volterra.us
-  SHORT_FORM: /^https?:\/\/([^./]+)\.(staging\.)?volterra\.us\/?/i,
-  // Match console URLs: tenant.console.ves.volterra.io
+  // Match staging short-form URLs: tenant.staging.volterra.us (keep as-is)
+  STAGING_SHORT_FORM: /^https?:\/\/([^./]+)\.staging\.volterra\.us\/?/i,
+  // Match production short-form URLs: tenant.volterra.us (convert to console.ves)
+  PROD_SHORT_FORM: /^https?:\/\/([^./]+)\.volterra\.us\/?/i,
+  // Match console URLs: tenant.console.ves.volterra.io or tenant.staging.console.ves.volterra.io
   CONSOLE_FORM: /^https?:\/\/([^./]+)\.(staging\.)?console\.ves\.volterra\.io\/?/i,
   // Trailing slashes and /api suffix
   TRAILING_CLEANUP: /\/+$|\/api\/?$/gi,
@@ -81,8 +83,8 @@ const URL_PATTERNS = {
  * Normalize F5XC tenant URL to standard API endpoint format
  *
  * Handles various input formats:
- * - tenant.volterra.us -> tenant.console.ves.volterra.io/api
- * - tenant.staging.volterra.us -> tenant.staging.console.ves.volterra.io/api
+ * - tenant.volterra.us -> tenant.console.ves.volterra.io/api (production)
+ * - tenant.staging.volterra.us -> tenant.staging.volterra.us/api (staging - keep as-is)
  * - tenant.console.ves.volterra.io -> tenant.console.ves.volterra.io/api
  * - Any of the above with trailing slashes or /api suffix
  *
@@ -93,12 +95,20 @@ export function normalizeApiUrl(input: string): string {
   // Remove trailing slashes and existing /api suffix
   let url = input.replace(URL_PATTERNS.TRAILING_CLEANUP, "");
 
-  // Handle short-form URLs (tenant.volterra.us)
-  const shortFormMatch = url.match(URL_PATTERNS.SHORT_FORM);
-  if (shortFormMatch) {
-    const tenant = shortFormMatch[1];
-    const staging = shortFormMatch[2] ?? "";
-    url = `https://${tenant}.${staging}console.ves.volterra.io`;
+  // Handle staging short-form URLs - keep as-is (don't convert to console.ves)
+  const stagingMatch = url.match(URL_PATTERNS.STAGING_SHORT_FORM);
+  if (stagingMatch) {
+    const tenant = stagingMatch[1];
+    url = `https://${tenant}.staging.volterra.us`;
+    // Ensure /api suffix and return early
+    return `${url}/api`;
+  }
+
+  // Handle production short-form URLs (tenant.volterra.us -> tenant.console.ves.volterra.io)
+  const prodMatch = url.match(URL_PATTERNS.PROD_SHORT_FORM);
+  if (prodMatch) {
+    const tenant = prodMatch[1];
+    url = `https://${tenant}.console.ves.volterra.io`;
   }
 
   // Handle console URLs - ensure https

--- a/src/tools/discovery/execute.ts
+++ b/src/tools/discovery/execute.ts
@@ -109,6 +109,24 @@ function buildQueryString(queryParams: Record<string, string | string[]>): strin
 }
 
 /**
+ * Normalize tool path by removing /api prefix.
+ * The baseURL already includes /api, so we strip it from tool paths
+ * to avoid double /api in the final URL.
+ *
+ * This ensures users can enter any URL format and the path will be
+ * correctly constructed:
+ * - tenant.volterra.us → normalized to tenant.console.ves.volterra.io/api
+ * - Tool paths like /api/config/... → stripped to /config/...
+ * - Final URL: baseURL + normalizedPath = correct single /api path
+ */
+function normalizeToolPath(path: string): string {
+  if (path.startsWith("/api/")) {
+    return path.slice(4); // Remove '/api', keep the leading '/'
+  }
+  return path;
+}
+
+/**
  * Generate curl command example
  */
 function generateCurlCommand(
@@ -116,7 +134,7 @@ function generateCurlCommand(
   params: ExecuteToolParams,
   apiUrl: string
 ): string {
-  const path = buildPath(tool.path, params.pathParams ?? {});
+  const path = buildPath(normalizeToolPath(tool.path), params.pathParams ?? {});
   const queryString = buildQueryString(params.queryParams ?? {});
   const fullUrl = `${apiUrl}${path}${queryString}`;
 
@@ -235,7 +253,7 @@ export async function executeTool(
   // Authenticated mode - execute API call
   try {
     const httpClient = createHttpClient(creds);
-    const path = buildPath(tool.path, pathParams);
+    const path = buildPath(normalizeToolPath(tool.path), pathParams);
     const queryString = buildQueryString(queryParams);
     const fullPath = `${path}${queryString}`;
 

--- a/tests/unit/credential-manager.test.ts
+++ b/tests/unit/credential-manager.test.ts
@@ -49,9 +49,10 @@ describe("normalizeApiUrl", () => {
     );
   });
 
-  it("should normalize staging URL", () => {
+  it("should normalize staging URL (keep as-is)", () => {
+    // Staging URLs use the short-form domain directly, not console.ves.volterra.io
     expect(normalizeApiUrl("https://mytenant.staging.volterra.us")).toBe(
-      "https://mytenant.staging.console.ves.volterra.io/api"
+      "https://mytenant.staging.volterra.us/api"
     );
   });
 


### PR DESCRIPTION
## Summary
- Fix double `/api` path bug that caused API calls to return HTML instead of JSON
- Fix staging URL normalization to keep `*.staging.volterra.us` URLs as-is

## Problem
API calls were returning HTML (F5 XC web console login page) instead of JSON responses due to two issues:

1. **Double /api path**: BaseURL includes `/api`, tool paths from OpenAPI specs also start with `/api`, resulting in `/api/api/...` URLs
2. **Staging URL conversion**: Staging URLs were incorrectly converted to `*.staging.console.ves.volterra.io` which doesn't exist

## Solution
1. Added `normalizeToolPath()` helper in `execute.ts` to strip `/api` prefix from tool paths
2. Updated `normalizeApiUrl()` in `credential-manager.ts` to keep staging URLs as-is

## Test plan
- [x] All 1216 tests pass
- [x] Verified with production tenant (f5-amer-ent) - Status 200 ✅
- [x] Verified with staging tenant (nferreira) - Status 200 ✅
- [x] Pre-commit hooks pass (ESLint, Prettier, TypeScript)

## Files changed
- `src/tools/discovery/execute.ts` - Added `normalizeToolPath()` helper
- `src/auth/credential-manager.ts` - Fixed staging URL handling
- `tests/unit/credential-manager.test.ts` - Updated test expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)