### PR TITLE
fix(ci): auto-merge openapi-sync PRs and prevent accumulation

### DIFF
--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -42,6 +42,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Close existing openapi-sync PRs
+        run: |
+          # Close any existing openapi-sync PRs to prevent accumulation
+          EXISTING_PRS=$(gh pr list --state open --head "openapi-sync/" --json number --jq '.[].number' || true)
+          for PR in $EXISTING_PRS; do
+            echo "Closing existing PR #$PR"
+            gh pr close "$PR" --comment "Superseded by newer OpenAPI sync" || true
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download OpenAPI specs from enriched source
         run: npm run sync-specs
         env:
@@ -115,6 +126,7 @@ jobs:
           fi
 
       - name: Create Pull Request
+        id: create-pr
         if: steps.changes.outputs.changed == 'true' || github.event.inputs.force_regenerate == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
@@ -153,6 +165,13 @@ jobs:
             automated
             openapi
             dependencies
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        run: |
+          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
Fixes the PR accumulation problem from openapi-sync workflow.

### Changes
- **Close existing PRs**: Before creating a new PR, closes any existing `openapi-sync/*` PRs to prevent accumulation
- **Enable auto-merge**: Uses `gh pr merge --auto --squash` to automatically merge PRs once CI passes

### Problem Solved
- 9 stale PRs were piling up (#91, #92, #96, #99, #100, #101, #102, #103, #104) - all now closed
- Future PRs will auto-merge after CI passes, triggering the fully automated release workflow

### Automation Flow
```
OpenAPI Sync → Creates PR → Auto-merge → Push to main → Release workflow → npm + Docker + MCPB
```

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI passes
- [ ] Next openapi-sync run auto-merges successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)