### PR TITLE
fix: copy scripts directory in Dockerfile for version generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,14 @@ COPY package*.json ./
 # The prepare script runs npm build, but tsconfig.json isn't copied yet
 RUN npm ci --ignore-scripts
 
-# Copy source files
+# Copy source files and scripts
 COPY tsconfig.json ./
 COPY src/ ./src/
+COPY scripts/ ./scripts/
+COPY specs/index.json ./specs/
 
 # Build TypeScript (now that all source files are present)
+# The prebuild hook runs generate:version which needs scripts/
 RUN npm run build
 
 # Prune dev dependencies


### PR DESCRIPTION
## Summary
Fixes Docker build failure caused by missing `scripts/` directory in container.

## Problem
The `prebuild` hook added in PR #116 runs `npm run generate:version` which needs `scripts/generate-version.ts`. The Dockerfile wasn't copying the scripts directory.

## Changes
- Copy `scripts/` directory into Docker build stage
- Copy `specs/index.json` for upstream version detection

## Test plan
- [ ] Docker build succeeds
- [ ] Version displayed correctly in container

🤖 Generated with [Claude Code](https://claude.com/claude-code)