### PR TITLE
fix: update .dockerignore to include scripts for version generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,8 +52,10 @@ tmp
 temp
 *.tmp
 
-# Scripts not needed in production
-scripts
+# Test scripts not needed in production
+scripts/generate-test-fixtures.ts
+scripts/validate-*.ts
 
-# Specs (OpenAPI)
-specs
+# OpenAPI specs (except index.json needed for version info)
+specs/*.json
+!specs/index.json


### PR DESCRIPTION
## Summary
Fixes Docker build failure by updating .dockerignore to include files needed for version generation.

## Problem
The `prebuild` hook runs `npm run generate:version` which needs:
- `scripts/generate-version.ts`
- `specs/index.json` (for upstream version)

These were excluded by `.dockerignore`.

## Changes
- Include `scripts/` directory (except test-related scripts)
- Include `specs/index.json` for upstream version detection

## Test plan
- [ ] Docker build succeeds
- [ ] Version displayed correctly in container

🤖 Generated with [Claude Code](https://claude.com/claude-code)