### PR TITLE
fix: pymdownx.emoji Python 3.12 compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,9 +47,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
 
       - name: Install dependencies
-        run: |
-          pip install --no-cache-dir --force-reinstall pymdown-extensions>=10.8
-          pip install --upgrade -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Build documentation
         run: mkdocs build --strict

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,8 +77,8 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: ""
-      emoji_generator: ""
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -95,7 +95,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: ""
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:


### PR DESCRIPTION
## Summary

Fixes the Documentation workflow failure caused by pymdownx.emoji incompatibility with Python 3.12.

## Root Cause

The `emoji_index` and `emoji_generator` were set to empty strings (`""`), causing Python 3.12's `inspect.getfullargspec()` to raise `TypeError: unsupported callable`.

## Solution

Configure pymdownx.emoji to use Material for MkDocs built-in emoji functions:
- `emoji_index: !!python/name:material.extensions.emoji.twemoji`
- `emoji_generator: !!python/name:material.extensions.emoji.to_svg`

Also fixed superfences mermaid format configuration.

## Changes

- `mkdocs.yml`: Set proper emoji_index, emoji_generator, and mermaid format
- `.github/workflows/docs.yml`: Remove force-reinstall workaround

## Test Plan

- [x] `mkdocs build --strict` passes locally
- [ ] Documentation workflow passes in CI

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)