### PR TITLE
feat: integrate v2.0.5 discovery metadata and CLI enhancements

### DIFF
--- a/src/generator/domain-metadata.ts
+++ b/src/generator/domain-metadata.ts
@@ -14,7 +14,49 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /**
- * CLI metadata for quick start examples
+ * Workflow step in a common workflow (v2.0.5+)
+ */
+export interface WorkflowStep {
+  /** Step number in sequence */
+  step: number;
+  /** Command to execute */
+  command: string;
+  /** Description of what this step does */
+  description: string;
+}
+
+/**
+ * Common workflow for domain operations (v2.0.5+)
+ */
+export interface CommonWorkflow {
+  /** Workflow name */
+  name: string;
+  /** Workflow description */
+  description: string;
+  /** Ordered steps to execute */
+  steps: WorkflowStep[];
+  /** Prerequisites before starting workflow */
+  prerequisites?: string[];
+  /** Expected outcome after workflow completion */
+  expectedOutcome?: string;
+}
+
+/**
+ * Troubleshooting guide for common issues (v2.0.5+)
+ */
+export interface TroubleshootingGuide {
+  /** Problem description */
+  problem: string;
+  /** Observable symptoms */
+  symptoms: string[];
+  /** Commands to diagnose the issue */
+  diagnosisCommands: string[];
+  /** Possible solutions */
+  solutions: string[];
+}
+
+/**
+ * CLI metadata for quick start examples and workflows (v2.0.5+)
  */
 export interface CliMetadata {
   quick_start?: {
@@ -22,6 +64,12 @@ export interface CliMetadata {
     description: string;
     expected_output: string;
   };
+  /** Common workflows for this domain */
+  common_workflows?: CommonWorkflow[];
+  /** Troubleshooting guides for common issues */
+  troubleshooting?: TroubleshootingGuide[];
+  /** Domain icon */
+  icon?: string;
 }
 
 /**
@@ -159,13 +207,31 @@ interface RawSpecEntry {
   "x-f5xc-logo-svg"?: string;
   "x-f5xc-primary-resources": RawResourceEntry[];
   "x-f5xc-primary-resources-simple": string[];
-  // cli_metadata remains snake_case (wrapper field)
-  cli_metadata?: {
+  // x-f5xc-cli-metadata (v2.0.5+) contains structured CLI guidance
+  "x-f5xc-cli-metadata"?: {
     quick_start?: {
       command: string;
       description: string;
       expected_output: string;
     };
+    common_workflows?: Array<{
+      name: string;
+      description: string;
+      steps: Array<{
+        step: number;
+        command: string;
+        description: string;
+      }>;
+      prerequisites?: string[];
+      expected_outcome?: string;
+    }>;
+    troubleshooting?: Array<{
+      problem: string;
+      symptoms: string[];
+      diagnosis_commands: string[];
+      solutions: string[];
+    }>;
+    icon?: string;
   };
 }
 
@@ -210,8 +276,38 @@ function transformResourceEntry(raw: RawResourceEntry): ResourceMetadata {
 }
 
 /**
+ * Transform raw CLI metadata to camelCase CliMetadata (v2.0.5+)
+ */
+function transformCliMetadata(raw: RawSpecEntry["x-f5xc-cli-metadata"]): CliMetadata | undefined {
+  if (!raw) return undefined;
+
+  return {
+    quick_start: raw.quick_start,
+    common_workflows: raw.common_workflows?.map((wf) => ({
+      name: wf.name,
+      description: wf.description,
+      steps: wf.steps.map((s) => ({
+        step: s.step,
+        command: s.command,
+        description: s.description,
+      })),
+      prerequisites: wf.prerequisites,
+      expectedOutcome: wf.expected_outcome,
+    })),
+    troubleshooting: raw.troubleshooting?.map((ts) => ({
+      problem: ts.problem,
+      symptoms: ts.symptoms,
+      diagnosisCommands: ts.diagnosis_commands,
+      solutions: ts.solutions,
+    })),
+    icon: raw.icon,
+  };
+}
+
+/**
  * Transform raw spec entry (x-f5xc-* namespace) to DomainMetadata (camelCase)
  * v2.0.0+: x-f5xc-category replaces both domain_category and ui_category
+ * v2.0.5+: x-f5xc-cli-metadata contains workflows and troubleshooting
  */
 function transformSpecEntry(raw: RawSpecEntry): DomainMetadata {
   // x-f5xc-category is a DRY consolidation of domain_category and ui_category
@@ -237,7 +333,7 @@ function transformSpecEntry(raw: RawSpecEntry): DomainMetadata {
     primaryResourcesSimple: raw["x-f5xc-primary-resources-simple"] || [],
     icon: raw["x-f5xc-icon"],
     logoSvg: raw["x-f5xc-logo-svg"],
-    cliMetadata: raw.cli_metadata,
+    cliMetadata: transformCliMetadata(raw["x-f5xc-cli-metadata"]),
   };
 }
 

--- a/src/generator/openapi-parser.ts
+++ b/src/generator/openapi-parser.ts
@@ -120,6 +120,9 @@ const OpenApiOperationSchema = z.object({
   "x-ves-required-fields": z.array(z.string()).optional(),
   "x-ves-confirmation-required": z.boolean().optional(),
   "x-ves-operation-metadata": OperationMetadataSchema.optional(),
+  // Discovery metadata from live API exploration (v2.0.5+)
+  "x-discovered-response-time-ms": z.number().optional(),
+  "x-discovered-sample-size": z.number().optional(),
 });
 
 const OpenApiPathItemSchema = z.object({
@@ -176,6 +179,16 @@ export interface CommonError {
 export interface PerformanceImpact {
   latency?: string;
   resource_usage?: string;
+}
+
+/**
+ * Discovery metadata from live API exploration (v2.0.5+)
+ */
+export interface DiscoveryMetadata {
+  /** API response time in milliseconds */
+  responseTimeMs?: number;
+  /** Number of samples collected during discovery */
+  sampleSize?: number;
 }
 
 /**
@@ -274,6 +287,10 @@ export interface ParsedOperation {
   oneOfGroups: OneOfGroup[];
   /** Subscription/addon service requirements */
   subscriptionRequirements: SubscriptionRequirement[];
+
+  // Discovery metadata (v2.0.5+)
+  /** API discovery metadata from live exploration */
+  discoveryMetadata?: DiscoveryMetadata;
 }
 
 /**
@@ -526,6 +543,17 @@ function extractDomainOperations(
       const confirmationRequired = operation["x-ves-confirmation-required"] ?? false;
       const operationMetadata = operation["x-ves-operation-metadata"] ?? null;
 
+      // Extract discovery metadata from live API exploration (v2.0.5+)
+      const discoveredResponseTimeMs = operation["x-discovered-response-time-ms"];
+      const discoveredSampleSize = operation["x-discovered-sample-size"];
+      const discoveryMetadata: DiscoveryMetadata | undefined =
+        discoveredResponseTimeMs !== undefined || discoveredSampleSize !== undefined
+          ? {
+              responseTimeMs: discoveredResponseTimeMs,
+              sampleSize: discoveredSampleSize,
+            }
+          : undefined;
+
       // Extract parameter-level metadata (examples, validation rules, displaynames)
       const parameterExamples: Record<string, string> = {};
       const validationRules: Record<string, Record<string, string>> = {};
@@ -601,6 +629,8 @@ function extractDomainOperations(
         dependencies,
         oneOfGroups: extractedDeps.oneOfGroups,
         subscriptionRequirements,
+        // Discovery metadata (v2.0.5+)
+        discoveryMetadata,
       });
     }
   }

--- a/src/tools/discovery/best-practices.ts
+++ b/src/tools/discovery/best-practices.ts
@@ -10,6 +10,7 @@
 
 import { getToolIndex } from "./index-loader.js";
 import { getResourcesInDomain, getAllDependencyDomains } from "./dependencies.js";
+import { getDomainMetadata, type TroubleshootingGuide } from "../../generator/domain-metadata.js";
 
 /**
  * Common error pattern with resolution guidance
@@ -95,6 +96,8 @@ export interface DomainBestPractices {
   securityNotes: string[];
   /** Performance tips */
   performanceTips: string[];
+  /** Troubleshooting guides from upstream CLI metadata (v2.0.5+) */
+  troubleshootingGuides?: TroubleshootingGuide[];
 }
 
 /**
@@ -458,6 +461,10 @@ export function getDomainBestPractices(domain: string): DomainBestPractices | nu
     description: `Operations for ${domain} resources`,
   };
 
+  // Get troubleshooting guides from upstream CLI metadata (v2.0.5+)
+  const domainMeta = getDomainMetadata(domain);
+  const troubleshootingGuides = domainMeta?.cliMetadata?.troubleshooting;
+
   return {
     domain,
     displayName: info.displayName,
@@ -469,6 +476,7 @@ export function getDomainBestPractices(domain: string): DomainBestPractices | nu
     workflows: generateWorkflows(domain),
     securityNotes: DOMAIN_SECURITY_NOTES[domain] ?? [],
     performanceTips: DOMAIN_PERFORMANCE_TIPS[domain] ?? [],
+    troubleshootingGuides,
   };
 }
 
@@ -654,6 +662,26 @@ export function formatBestPractices(practices: DomainBestPractices): string {
       lines.push(`- ${tip}`);
     }
     lines.push("");
+  }
+
+  if (practices.troubleshootingGuides && practices.troubleshootingGuides.length > 0) {
+    lines.push("## Troubleshooting Guides");
+    for (const guide of practices.troubleshootingGuides) {
+      lines.push(`### ${guide.problem}`);
+      lines.push("**Symptoms**:");
+      for (const symptom of guide.symptoms) {
+        lines.push(`- ${symptom}`);
+      }
+      lines.push("**Diagnosis**:");
+      for (const cmd of guide.diagnosisCommands) {
+        lines.push(`- ${cmd}`);
+      }
+      lines.push("**Solutions**:");
+      for (const solution of guide.solutions) {
+        lines.push(`- ${solution}`);
+      }
+      lines.push("");
+    }
   }
 
   return lines.join("\n");

--- a/src/tools/discovery/index-loader.ts
+++ b/src/tools/discovery/index-loader.ts
@@ -43,6 +43,8 @@ function generateIndex(): ToolIndex {
       supportsLogs: resourceMeta?.supportsLogs ?? false,
       supportsMetrics: resourceMeta?.supportsMetrics ?? false,
       resourceTier: resourceMeta?.tier ?? null,
+      // Discovery metadata from live API exploration (v2.0.5+)
+      discoveryResponseTimeMs: tool.discoveryMetadata?.responseTimeMs,
     };
   });
 

--- a/src/tools/discovery/types.ts
+++ b/src/tools/discovery/types.ts
@@ -41,6 +41,8 @@ export interface ToolIndexEntry {
   supportsMetrics: boolean;
   /** Resource tier requirement (v1.0.84+) */
   resourceTier: string | null;
+  /** API response time from live discovery in ms (v2.0.5+) */
+  discoveryResponseTimeMs?: number;
 }
 
 /**

--- a/tests/unit/discovery.test.ts
+++ b/tests/unit/discovery.test.ts
@@ -470,8 +470,8 @@ describe("Token Efficiency Validation", () => {
     const index = getToolIndex();
     const sampleEntry = index.tools[0];
 
-    // Each entry should have 14 fields:
-    // 5 core + Phase A metadata + domain metadata + resource metadata (v1.0.84+)
+    // Each entry should have 15 fields:
+    // 5 core + Phase A metadata + domain metadata + resource metadata (v1.0.84+) + discovery (v2.0.5+)
     const fields = Object.keys(sampleEntry);
     expect(fields).toEqual([
       "name",
@@ -489,6 +489,8 @@ describe("Token Efficiency Validation", () => {
       "supportsLogs",
       "supportsMetrics",
       "resourceTier",
+      // v2.0.5+ discovery metadata
+      "discoveryResponseTimeMs",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- Add support for v2.0.5 discovery metadata (x-discovered-response-time-ms, x-discovered-sample-size)
- Integrate enhanced CLI metadata (common_workflows, troubleshooting guides, icons)
- Add new interfaces: WorkflowStep, CommonWorkflow, TroubleshootingGuide, DiscoveryMetadata
- Include troubleshooting guides in best practices output

## Changes
- 6 files changed (+166, -6 lines)
- All new fields are optional for backward compatibility

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (1717 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #134