### PR TITLE
refactor: clean break - remove dead backward compatibility code and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release of F5 Distributed Cloud API MCP Server
-- 270+ API tools auto-generated from OpenAPI specifications
+- 1500+ API tools auto-generated from enriched OpenAPI specifications across 23 domains
 - Dual-mode operation: documentation mode (unauthenticated) and execution mode (authenticated)
 - API token authentication support
 - P12 certificate (mTLS) authentication support
 - Automatic URL normalization for various F5XC URL formats
 - CURL examples for all API operations
 - MCP Resources for F5XC configuration objects via URI scheme
-- Workflow prompts for common operations:
-  - `deploy-http-loadbalancer` - Deploy HTTP Load Balancer with origin pool
-  - `configure-waf` - Configure Web Application Firewall
-  - `create-multicloud-site` - Deploy F5XC site in AWS/Azure/GCP
+- Workflow prompts sourced from upstream x-f5xc-guided-workflows extension:
+  - `deploy_http_loadbalancer` - Create HTTP load balancer with origin pool
+  - `deploy_https_loadbalancer` - Create HTTPS load balancer with SSL/TLS termination
+  - `enable_waf_protection` - Add WAF to existing load balancer
+  - `configure_origin_pool` - Set up backend server pool with health checks
+  - `configure_dns_zone` - Set up authoritative DNS zone with records
+  - `enable_cdn_distribution` - Configure CDN for content delivery
+  - `register_site` - Register and configure a CE site
 - Subscription tier awareness (NO_TIER, STANDARD, ADVANCED)
 - Comprehensive documentation site with MkDocs
 - Docker container distribution via GHCR
@@ -41,20 +45,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automated npm publishing
   - Documentation deployment to GitHub Pages
 
-### API Domains
+### API Domains (23 Total)
 
-- `waap` - HTTP/TCP load balancers, origin pools, app firewalls, rate limiters
-- `dns` - DNS zones, DNS load balancers, DNS LB pools
-- `network` - Network connectors, firewalls, enhanced firewall policies
-- `site` - AWS VPC sites, Azure VNET sites, GCP VPC sites, customer edge
-- `appstack` - K8s clusters, virtual K8s, workloads
-- `security` - Service policies, WAF, malicious user detection
-- `core` - Namespaces, certificates, cloud credentials
+Tools organized by enriched domains including:
+
+- Load Balancing - HTTP/TCP/UDP load balancers, origin pools
+- Networking - Network connectors, firewalls, interfaces, policies
+- Security - Service policies, WAF, malicious user mitigation
+- Infrastructure - AWS/Azure/GCP VPC sites, customer edge sites
+- DNS - DNS zones, DNS load balancers, DNS pools
+- CDN - CDN load balancers, cache rules
+- Observability - Alerts, logs, synthetic monitors, metrics
+- Identity - Authentication, users, roles, RBAC
+- Bot Defense - Bot defense, client-side defense
+- And 14 more domains with full API coverage
+
+See README.md for complete domain list with path counts.
 
 ### Technical
 
 - TypeScript 5.x with strict mode
-- Node.js 20+ LTS runtime
+- Node.js 24+ runtime
 - @modelcontextprotocol/sdk for MCP implementation
 - Zod for runtime validation
 - Axios with mTLS support for HTTP client

--- a/README.md
+++ b/README.md
@@ -315,11 +315,15 @@ The generator automatically:
 
 ## Workflow Prompts
 
-The server includes guided workflow prompts:
+The server includes guided workflow prompts sourced from upstream enriched specs:
 
-- `deploy-http-loadbalancer` - Deploy HTTP LB with origin pool
-- `configure-waf` - Configure Web Application Firewall
-- `create-multicloud-site` - Deploy F5XC site in AWS/Azure/GCP
+- `deploy_http_loadbalancer` - Create a fully configured HTTP load balancer with backend origin pool
+- `deploy_https_loadbalancer` - Create HTTPS load balancer with SSL/TLS termination
+- `enable_waf_protection` - Add web application firewall to existing load balancer
+- `configure_origin_pool` - Set up backend server pool with health checks
+- `configure_dns_zone` - Set up authoritative DNS zone with records
+- `enable_cdn_distribution` - Configure CDN for content delivery
+- `register_site` - Register and configure a CE site
 
 ## Resource URIs
 

--- a/src/generator/domain-metadata.ts
+++ b/src/generator/domain-metadata.ts
@@ -143,10 +143,8 @@ export interface DomainMetadata {
   useCases: string[];
   /** Related domain names */
   relatedDomains: string[];
-  /** Primary resource types with rich metadata (v1.0.84+) */
+  /** Primary resource types with rich metadata */
   primaryResources: ResourceMetadata[];
-  /** Simple list of resource names for backward compatibility */
-  primaryResourcesSimple: string[];
   /** Emoji icon */
   icon: string;
   /** SVG logo data URI */
@@ -330,7 +328,6 @@ function transformSpecEntry(raw: RawSpecEntry): DomainMetadata {
     useCases: raw["x-f5xc-use-cases"] || [],
     relatedDomains: raw["x-f5xc-related-domains"] || [],
     primaryResources: (raw["x-f5xc-primary-resources"] || []).map(transformResourceEntry),
-    primaryResourcesSimple: raw["x-f5xc-primary-resources-simple"] || [],
     icon: raw["x-f5xc-icon"],
     logoSvg: raw["x-f5xc-logo-svg"],
     cliMetadata: transformCliMetadata(raw["x-f5xc-cli-metadata"]),
@@ -396,18 +393,6 @@ function buildResourceCaches(): void {
       const kebab = resource.name.toLowerCase().replace(/_/g, "-");
       resourceToDomainCache.set(kebab, spec);
       resourceMetadataCache.set(kebab, resource);
-    }
-
-    // Also index from primaryResourcesSimple for backward compatibility
-    for (const resourceName of spec.primaryResourcesSimple) {
-      const normalized = resourceName.toLowerCase().replace(/-/g, "_");
-      if (!resourceToDomainCache.has(normalized)) {
-        resourceToDomainCache.set(normalized, spec);
-      }
-      const kebab = resourceName.toLowerCase().replace(/_/g, "-");
-      if (!resourceToDomainCache.has(kebab)) {
-        resourceToDomainCache.set(kebab, spec);
-      }
     }
   }
 }
@@ -503,19 +488,10 @@ export function getResourceToDomainMap(): Record<string, string> {
   const map: Record<string, string> = {};
 
   for (const spec of index.specifications) {
-    // Use rich primaryResources with resource.name
     for (const resource of spec.primaryResources) {
       // Use kebab-case as the key (consistent with tool naming)
       const kebabCase = resource.name.toLowerCase().replace(/_/g, "-");
       map[kebabCase] = spec.domain;
-    }
-
-    // Also include primaryResourcesSimple for backward compatibility
-    for (const resourceName of spec.primaryResourcesSimple) {
-      const kebabCase = resourceName.toLowerCase().replace(/_/g, "-");
-      if (!map[kebabCase]) {
-        map[kebabCase] = spec.domain;
-      }
     }
   }
 

--- a/src/generator/naming/acronyms.ts
+++ b/src/generator/naming/acronyms.ts
@@ -33,7 +33,7 @@ function buildAcronymMap(): Map<string, string> {
 
 /**
  * Get all technical acronyms as a simple string array
- * For backward compatibility with code expecting TECHNICAL_ACRONYMS
+ * Sourced from upstream x-f5xc-acronyms extension
  */
 export function getTechnicalAcronyms(): readonly string[] {
   const acronyms = getAcronyms();


### PR DESCRIPTION
## Summary
- Remove dead `primaryResourcesSimple` from domain-metadata.ts
- Remove backward compatibility indexing code (upstream extension no longer exists)
- Fix misleading "backward compatibility" comment in acronyms.ts
- Update README.md with correct workflow prompt names
- Update CHANGELOG.md with accurate tool counts, domains, and workflows

## Changes
- 4 files changed (+36, -45 lines)
- Net removal of dead code

## Test plan
- [x] All 1705 tests pass
- [x] Build succeeds
- [x] Pre-commit hooks pass
- [x] No remaining legacy patterns in active code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #146