### PR TITLE
docs: fix OpenCode MCP server configuration format

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ Add to your MCP settings:
 }
 ```
 
+### OpenCode
+
+Add to `opencode.json` (project root or `~/.config/opencode/opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "f5xc-api": {
+      "type": "local",
+      "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"],
+      "environment": {
+        "F5XC_API_URL": "https://your-tenant.console.ves.volterra.io",
+        "F5XC_API_TOKEN": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+> **Note:** OpenCode uses different schema: `"mcp"` key (not `"mcpServers"`), array-based
+> `"command"`, `"environment"` (not `"env"`), and requires `"type": "local"`.
+
 ## Environment Variables
 
 | Variable | Required | Description |

--- a/docs/configuration/mcp-json.md
+++ b/docs/configuration/mcp-json.md
@@ -11,9 +11,21 @@ Complete reference for MCP server configuration files.
 | Claude Desktop (Linux) | `~/.config/Claude/claude_desktop_config.json` |
 | Claude Code (Project) | `.mcp.json` in project root |
 | Claude Code (Global) | `~/.claude/mcp.json` |
+| OpenCode (Project) | `opencode.json` or `opencode.jsonc` in project root |
+| OpenCode (Global) | `~/.config/opencode/opencode.json` |
 | VS Code (Cline) | Cline extension settings |
 | VS Code (Continue) | `~/.continue/config.json` |
 | Cursor | Cursor settings or `.cursor/mcp.json` |
+
+!!! note "OpenCode Configuration Differences"
+    OpenCode uses a different schema than Claude Desktop/Code:
+
+    - Top-level key: `"mcp"` (not `"mcpServers"`)
+    - Command format: `"command": ["npx", "package"]` (array, not separate command/args)
+    - Environment: `"environment"` (not `"env"`)
+    - Requires: `"type": "local"` for stdio servers
+
+    See [OpenCode Setup](../getting-started/opencode.md) for examples.
 
 ## Configuration Schema
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -185,5 +185,6 @@ Then log out and back in.
 
 - [Claude Desktop Setup](claude-desktop.md)
 - [Claude CLI Setup](claude-cli.md)
+- [OpenCode Setup](opencode.md)
 - [VS Code Setup](vscode.md)
 - [Authentication Configuration](../configuration/authentication.md)

--- a/docs/getting-started/opencode.md
+++ b/docs/getting-started/opencode.md
@@ -10,38 +10,35 @@ Configure the F5XC API MCP Server with OpenCode AI Assistant for natural languag
 
 ### Step 1: Locate Config File
 
-OpenCode uses MCP configuration files. The location depends on your setup:
+OpenCode uses `opencode.json` or `opencode.jsonc` configuration files:
 
 === "Project Configuration"
 
     ```text
-    .opencode/mcp.json
+    opencode.json
     ```
+
+    (in your project root directory)
 
 === "Global Configuration"
 
     ```text
-    ~/.opencode/mcp.json
+    ~/.config/opencode/opencode.json
     ```
-
-Create the configuration directory and file if they don't exist:
-
-```bash
-mkdir -p .opencode
-```
 
 ### Step 2: Add MCP Server
 
-Edit the config file and add the F5XC API server:
+Edit the config file and add the F5XC API server under the `mcp` key:
 
 === "Documentation Mode (No Auth)"
 
     ```json
     {
-      "mcpServers": {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
         "f5xc-api": {
-          "command": "npx",
-          "args": ["@robinmordasiewicz/f5xc-api-mcp"]
+          "type": "local",
+          "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"]
         }
       }
     }
@@ -51,11 +48,12 @@ Edit the config file and add the F5XC API server:
 
     ```json
     {
-      "mcpServers": {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
         "f5xc-api": {
-          "command": "npx",
-          "args": ["@robinmordasiewicz/f5xc-api-mcp"],
-          "env": {
+          "type": "local",
+          "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"],
+          "environment": {
             "F5XC_API_URL": "https://your-tenant.console.ves.volterra.io",
             "F5XC_API_TOKEN": "your-api-token"
           }
@@ -68,11 +66,12 @@ Edit the config file and add the F5XC API server:
 
     ```json
     {
-      "mcpServers": {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
         "f5xc-api": {
-          "command": "npx",
-          "args": ["@robinmordasiewicz/f5xc-api-mcp"],
-          "env": {
+          "type": "local",
+          "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"],
+          "environment": {
             "F5XC_API_URL": "https://your-tenant.console.ves.volterra.io",
             "F5XC_P12_BUNDLE": "/path/to/certificate.p12",
             "F5XC_P12_PASSWORD": "your-password"
@@ -86,15 +85,33 @@ Edit the config file and add the F5XC API server:
 
     ```json
     {
-      "mcpServers": {
+      "$schema": "https://opencode.ai/config.json",
+      "mcp": {
         "f5xc-api": {
-          "command": "docker",
-          "args": [
-            "run", "-i", "--rm",
+          "type": "local",
+          "command": [
+            "docker", "run", "-i", "--rm",
             "-e", "F5XC_API_URL=https://your-tenant.console.ves.volterra.io",
             "-e", "F5XC_API_TOKEN=your-api-token",
             "ghcr.io/robinmordasiewicz/f5xc-api-mcp"
           ]
+        }
+      }
+    }
+    ```
+
+!!! tip "Adding to Existing Config"
+    If you already have an `opencode.json` with other settings, add the `mcp` section alongside your existing configuration:
+
+    ```json
+    {
+      "$schema": "https://opencode.ai/config.json",
+      "provider": { ... },
+      "plugin": [ ... ],
+      "mcp": {
+        "f5xc-api": {
+          "type": "local",
+          "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"]
         }
       }
     }
@@ -122,27 +139,46 @@ You can run multiple MCP servers alongside F5XC:
 
 ```json
 {
-  "mcpServers": {
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
     "f5xc-api": {
-      "command": "npx",
-      "args": ["@robinmordasiewicz/f5xc-api-mcp"]
+      "type": "local",
+      "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"]
     },
     "filesystem": {
-      "command": "npx",
-      "args": ["@modelcontextprotocol/server-filesystem", "/path/to/allowed/dir"]
+      "type": "local",
+      "command": ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/path/to/allowed/dir"]
     }
   }
 }
 ```
 
+## Configuration Reference
+
+### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `type` | Must be `"local"` for stdio-based MCP servers |
+| `command` | Array of command and arguments (e.g., `["npx", "package-name"]`) |
+
+### Optional Fields
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `environment` | Object with environment variables | `{}` |
+| `enabled` | Whether to load the server on startup | `true` |
+| `timeout` | Response timeout in milliseconds | `5000` |
+
 ## Troubleshooting
 
 ### Server Not Loading
 
-1. Check the config file is valid JSON (use a JSON validator)
-2. Ensure the file path is correct for your OpenCode setup
-3. Completely quit OpenCode AI Assistant (not just close window)
-4. Check OpenCode logs for errors
+1. Validate JSON syntax (use a JSON validator or `.jsonc` for comments)
+2. Ensure `type: "local"` is specified
+3. Verify `command` is an array, not a string
+4. Completely quit OpenCode (not just close window)
+5. Check OpenCode logs for errors
 
 ### Authentication Issues
 
@@ -166,7 +202,7 @@ If npx fails to find the package:
 # Clear npx cache
 npx clear-npx-cache
 
-# Or use full package path
+# Or use -y flag to auto-confirm
 npx -y @robinmordasiewicz/f5xc-api-mcp
 ```
 
@@ -178,10 +214,11 @@ If Node.js isn't in your PATH:
 
 ```json
 {
-  "mcpServers": {
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
     "f5xc-api": {
-      "command": "/usr/local/bin/node",
-      "args": ["/path/to/f5xc-api-mcp/dist/index.js"]
+      "type": "local",
+      "command": ["/usr/local/bin/node", "/path/to/f5xc-api-mcp/dist/index.js"]
     }
   }
 }
@@ -193,12 +230,33 @@ Enable debug logging:
 
 ```json
 {
-  "mcpServers": {
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
     "f5xc-api": {
-      "command": "npx",
-      "args": ["@robinmordasiewicz/f5xc-api-mcp"],
-      "env": {
+      "type": "local",
+      "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"],
+      "environment": {
         "LOG_LEVEL": "debug"
+      }
+    }
+  }
+}
+```
+
+### Environment Variable References
+
+OpenCode supports environment variable references using `{env:VAR_NAME}` syntax:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "f5xc-api": {
+      "type": "local",
+      "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"],
+      "environment": {
+        "F5XC_API_URL": "{env:F5XC_API_URL}",
+        "F5XC_API_TOKEN": "{env:F5XC_API_TOKEN}"
       }
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,6 +111,14 @@ Works with any MCP-compatible AI assistant:
 
     [:octicons-arrow-right-24: Setup Guide](getting-started/cursor.md)
 
+- :material-code-tags:{ .lg .middle } **OpenCode**
+
+    ---
+
+    AI assistant with MCP support
+
+    [:octicons-arrow-right-24: Setup Guide](getting-started/opencode.md)
+
 </div>
 
 ## Example Usage

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -69,6 +69,25 @@ Add to your project's `.mcp.json`:
 }
 ```
 
+### OpenCode
+
+Add to your `opencode.json` (project root or `~/.config/opencode/opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "f5xc-api": {
+      "type": "local",
+      "command": ["npx", "@robinmordasiewicz/f5xc-api-mcp"]
+    }
+  }
+}
+```
+
+!!! note "OpenCode uses different configuration format"
+    OpenCode uses `"mcp"` key (not `"mcpServers"`), array-based `"command"`, and requires `"type": "local"`.
+
 ## Step 3: Verify Installation
 
 Restart your AI assistant and ask:


### PR DESCRIPTION
## Summary
- Fix incorrect OpenCode configuration documentation
- Update all docs to use correct OpenCode schema format
- Add OpenCode to IDE Support sections across docs

## Changes
- `docs/getting-started/opencode.md` - Complete rewrite with correct format
- `docs/configuration/mcp-json.md` - Added OpenCode locations + schema differences
- `docs/quickstart.md` - Added OpenCode configuration section  
- `docs/index.md` - Added OpenCode card to IDE Support
- `docs/getting-started/installation.md` - Added OpenCode to Next Steps
- `README.md` - Added OpenCode configuration example

## Key Corrections
| Element | Wrong (before) | Correct (after) |
|---------|----------------|-----------------|
| Config file | `.opencode/mcp.json` | `opencode.json` |
| Top-level key | `"mcpServers"` | `"mcp"` |
| Command | `"command"` + `"args"` | `"command": [array]` |
| Environment | `"env"` | `"environment"` |
| Type field | Missing | `"type": "local"` |

## Test plan
- [x] Tested configuration with OpenCode v1.0.220
- [x] MCP server loads correctly
- [x] f5xc-api-server-info tool executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #161