### PR TITLE
fix: add missing TypeScript return types in paths.ts

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -50,24 +50,24 @@ export function getStateDir(): string {
  */
 export const paths = {
   // Config files (XDG_CONFIG_HOME)
-  get configDir() {
+  get configDir(): string {
     return getConfigDir();
   },
-  get profilesDir() {
+  get profilesDir(): string {
     return join(getConfigDir(), "profiles");
   },
-  get activeProfile() {
+  get activeProfile(): string {
     return join(getConfigDir(), "active_profile");
   },
-  get settings() {
+  get settings(): string {
     return join(getConfigDir(), "config.yaml");
   },
 
   // State files (XDG_STATE_HOME)
-  get stateDir() {
+  get stateDir(): string {
     return getStateDir();
   },
-  get history() {
+  get history(): string {
     return join(getStateDir(), "history");
   },
 };


### PR DESCRIPTION
## Summary
Add explicit return type annotations to getter functions in `src/config/paths.ts`.

## Changes
- Add `: string` return type to 6 getter functions in the `paths` object

## Warnings Fixed
| Line | Warning |
|------|---------|
| 53 | Missing return type on function (`configDir`) |
| 56 | Missing return type on function (`profilesDir`) |
| 59 | Missing return type on function (`activeProfile`) |
| 62 | Missing return type on function (`settings`) |
| 67 | Missing return type on function (`stateDir`) |
| 70 | Missing return type on function (`history`) |

## Test plan
- [x] Pre-commit hooks pass (ESLint, TypeScript check)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #163