### PR TITLE
docs: add OpenCode to getting started navigation

### DIFF
--- a/docs/getting-started/.pages
+++ b/docs/getting-started/.pages
@@ -3,5 +3,6 @@ nav:
   - installation.md
   - claude-desktop.md
   - claude-cli.md
+  - opencode.md
   - vscode.md
   - cursor.md


### PR DESCRIPTION
## Summary

This PR completes issue #155 by adding OpenCode AI Assistant to the documentation navigation.

### Changes

- Added opencode.md to docs/getting-started/.pages navigation

### Pre-existing Documentation

The following was already in place (from earlier work):
- docs/getting-started/opencode.md - Comprehensive setup guide with all authentication methods
- README.md - OpenCode configuration section in Configuration area

### Acceptance Criteria Met

- [x] OpenCode users can easily find and follow installation instructions
- [x] All authentication methods are documented (API token, P12 certificate, Docker)
- [x] Configuration examples are complete and accurate
- [x] Documentation navigation includes OpenCode

Closes #155
