### PR TITLE
fix: prevent /api/api duplication with URL normalization

### DIFF
--- a/docs/f5xc-auth-enhancement-spec.md
+++ b/docs/f5xc-auth-enhancement-spec.md
@@ -1,0 +1,203 @@
+# F5XC-Auth Package Enhancement: URL Normalization
+
+## Summary
+
+Add URL normalization to the `@robinmordasiewicz/f5xc-auth` package's `CredentialManager`
+to handle various user-provided URL formats automatically, creating a
+**single source of truth** for URL handling.
+
+## Problem Statement
+
+Users configure F5XC API URLs in various formats:
+
+- `https://tenant.console.ves.volterra.io` (standard)
+- `https://tenant.console.ves.volterra.io/api` (with /api suffix)
+- `tenant.console.ves.volterra.io` (no protocol)
+- `tenant.console.ves.volterra.io/api` (no protocol, with /api)
+- `https://tenant.staging.volterra.us` (staging environment)
+
+When these non-standard formats are passed to the `httpClient` (which has `/api` in its
+baseURL), it causes `/api/api` duplication resulting in 4xx errors.
+
+Currently, consumers of `@robinmordasiewicz/f5xc-auth` must normalize URLs themselves
+before or during `CredentialManager` initialization. This leads to:
+
+- Duplicated normalization logic across consumers
+- Inconsistent handling
+- Easy-to-miss edge cases
+
+## Proposed Solution
+
+### Option 1: Normalize in CredentialManager.initialize()
+
+Add URL normalization in the `CredentialManager.initialize()` method to automatically
+normalize the `F5XC_API_URL` environment variable.
+
+```typescript
+// In CredentialManager class
+async initialize(): Promise<void> {
+  // Normalize API URL from environment if present
+  const apiUrl = process.env.F5XC_API_URL;
+  if (apiUrl) {
+    process.env.F5XC_API_URL = this.normalizeUrl(apiUrl);
+  }
+
+  // ... existing initialization logic
+}
+
+private normalizeUrl(input: string): string {
+  let url = input.trim();
+
+  if (!url) return "";
+
+  // Add https:// protocol if missing
+  if (!url.match(/^https?:\/\//i)) {
+    url = `https://${url}`;
+  }
+
+  // Remove trailing slashes
+  url = url.replace(/\/+$/, "");
+
+  // Remove /api suffix (httpClient adds it)
+  url = url.replace(/\/api$/i, "");
+
+  // Validate and reconstruct
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ""}`;
+  } catch {
+    return url;
+  }
+}
+```
+
+### Option 2: Normalize in Profile Creation/Loading
+
+Normalize URLs when profiles are created or loaded:
+
+```typescript
+// In profile handling
+async saveProfile(profile: Profile): Promise<void> {
+  const normalizedProfile = {
+    ...profile,
+    apiUrl: this.normalizeUrl(profile.apiUrl)
+  };
+  // ... save logic
+}
+
+async loadProfile(name: string): Promise<Profile | null> {
+  const profile = await this._loadProfile(name);
+  if (profile) {
+    profile.apiUrl = this.normalizeUrl(profile.apiUrl);
+  }
+  return profile;
+}
+```
+
+### Option 3: Normalize in createHttpClient()
+
+Normalize URLs when creating the HTTP client:
+
+```typescript
+export function createHttpClient(credentialManager: CredentialManager): AxiosInstance {
+  const apiUrl = credentialManager.getApiUrl();
+  const normalizedUrl = normalizeUrl(apiUrl);
+
+  return axios.create({
+    baseURL: `${normalizedUrl}/api`,
+    // ... other config
+  });
+}
+```
+
+## Recommended Approach
+
+**Option 1 (CredentialManager.initialize())** is recommended because:
+
+1. Earliest possible normalization point
+2. Single source of truth - all downstream code gets normalized URLs
+3. No changes needed to profile storage format
+4. Backward compatible
+
+## URL Normalization Rules
+
+| Input | Output |
+|-------|--------|
+| `tenant.console.ves.volterra.io` | `https://tenant.console.ves.volterra.io` |
+| `tenant.console.ves.volterra.io/api` | `https://tenant.console.ves.volterra.io` |
+| `https://tenant.console.ves.volterra.io/api` | `https://tenant.console.ves.volterra.io` |
+| `https://tenant.console.ves.volterra.io/api/` | `https://tenant.console.ves.volterra.io` |
+| `tenant.console.ves.volterra.io` | `https://tenant.console.ves.volterra.io` |
+| `https://tenant.staging.volterra.us` | `https://tenant.staging.volterra.us` |
+| `http://localhost:8080/api` | `http://localhost:8080` |
+
+## Benefits
+
+1. **Single Source of Truth**: All URL normalization happens in one place
+2. **Consistent Behavior**: All consumers get normalized URLs automatically
+3. **Backward Compatible**: Existing correctly-formatted URLs unchanged
+4. **Error Prevention**: Eliminates `/api/api` duplication at the source
+5. **Reduced Duplication**: Consumers don't need to implement normalization
+
+## Implementation Notes
+
+### Export the Utility
+
+Consider exporting the normalization function for consumers who need it:
+
+```typescript
+export { normalizeUrl } from './utils/url-utils';
+```
+
+### Logging
+
+Add optional logging when URLs are normalized:
+
+```typescript
+if (normalizedUrl !== apiUrl) {
+  logger.info(`Normalized API URL: ${apiUrl} -> ${normalizedUrl}`);
+}
+```
+
+### Testing
+
+Add unit tests covering:
+
+- Protocol addition (http/https)
+- /api suffix stripping
+- Trailing slash removal
+- Whitespace trimming
+- Various F5XC domain patterns
+- Edge cases (empty string, malformed URLs)
+
+## Migration Path
+
+1. Add normalization to f5xc-auth package
+2. Release new version (minor version bump)
+3. Update f5xc-api-mcp to remove workaround normalization in server.ts
+4. Update other consumers to remove their normalization code
+
+## Current Workaround (f5xc-api-mcp)
+
+Until this enhancement is implemented in f5xc-auth, the workaround is in `server.ts`:
+
+```typescript
+// src/server.ts
+export async function createServer(): Promise<F5XCApiServer> {
+  // Normalize F5XC_API_URL before CredentialManager reads it
+  const apiUrl = process.env.F5XC_API_URL;
+  if (apiUrl) {
+    const normalizedUrl = normalizeF5XCUrl(apiUrl);
+    if (normalizedUrl !== apiUrl) {
+      logger.info(`Normalizing F5XC_API_URL: ${apiUrl} -> ${normalizedUrl}`);
+      process.env.F5XC_API_URL = normalizedUrl;
+    }
+  }
+
+  const credentialManager = new CredentialManager();
+  await credentialManager.initialize();
+  // ...
+}
+```
+
+This workaround should be removed once f5xc-auth handles normalization internally.

--- a/scripts/validate-url-fix.ts
+++ b/scripts/validate-url-fix.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env npx tsx
+/**
+ * End-to-End Validation Script for URL Normalization Fix
+ *
+ * This script tests the actual MCP server functionality with various URL formats
+ * to verify the /api/api duplication issue is fixed.
+ *
+ * Run with:
+ *   F5XC_API_URL=https://f5-amer-ent.console.ves.volterra.io \
+ *   F5XC_API_TOKEN='your-token' \
+ *   npx tsx scripts/validate-url-fix.ts
+ */
+
+import { CredentialManager, createHttpClient, AuthMode } from "@robinmordasiewicz/f5xc-auth";
+import { normalizeF5XCUrl, normalizePath } from "../src/utils/url-utils.js";
+import { buildApiPath } from "../src/resources/templates.js";
+
+interface TestResult {
+  name: string;
+  passed: boolean;
+  details: string;
+}
+
+const results: TestResult[] = [];
+
+function log(msg: string) {
+  console.log(msg);
+}
+
+function logTest(name: string, passed: boolean, details: string) {
+  const status = passed ? "✅ PASS" : "❌ FAIL";
+  console.log(`\n${status}: ${name}`);
+  console.log(`   ${details}`);
+  results.push({ name, passed, details });
+}
+
+async function runValidation() {
+  log("=" .repeat(60));
+  log("URL Normalization Fix - End-to-End Validation");
+  log("=" .repeat(60));
+
+  // Test 1: Check environment variables
+  log("\n--- Test 1: Environment Variables ---");
+  const originalApiUrl = process.env.F5XC_API_URL;
+  const apiToken = process.env.F5XC_API_TOKEN;
+
+  if (!originalApiUrl || !apiToken) {
+    log("ERROR: F5XC_API_URL and F5XC_API_TOKEN must be set");
+    process.exit(1);
+  }
+  logTest("Environment variables set", true, `Original URL: ${originalApiUrl}`);
+
+  // Normalize the URL before CredentialManager reads it (mimics server.ts behavior)
+  // This is the pattern until f5xc-auth package handles normalization internally
+  const normalizedEnvUrl = normalizeF5XCUrl(originalApiUrl);
+  if (normalizedEnvUrl !== originalApiUrl) {
+    log(`   Normalizing: ${originalApiUrl} -> ${normalizedEnvUrl}`);
+    process.env.F5XC_API_URL = normalizedEnvUrl;
+  }
+  logTest("URL normalized for CredentialManager", true, `Normalized URL: ${normalizedEnvUrl}`);
+
+  // Test 2: URL Normalization with various formats
+  log("\n--- Test 2: URL Normalization ---");
+  const urlFormats = [
+    { input: "https://f5-amer-ent.console.ves.volterra.io", desc: "standard" },
+    { input: "https://f5-amer-ent.console.ves.volterra.io/api", desc: "with /api" },
+    { input: "f5-amer-ent.console.ves.volterra.io", desc: "no protocol" },
+    { input: "f5-amer-ent.console.ves.volterra.io/api", desc: "no protocol with /api" },
+  ];
+
+  for (const { input, desc } of urlFormats) {
+    const normalized = normalizeF5XCUrl(input);
+    const expected = "https://f5-amer-ent.console.ves.volterra.io";
+    const passed = normalized === expected;
+    logTest(`URL normalization (${desc})`, passed, `${input} -> ${normalized}`);
+  }
+
+  // Test 3: Path Normalization prevents /api/api
+  log("\n--- Test 3: Path Normalization ---");
+  const resourcePath = buildApiPath("http_loadbalancer", "default");
+  if (resourcePath) {
+    const normalizedPath = normalizePath(resourcePath);
+    const baseUrl = "https://f5-amer-ent.console.ves.volterra.io/api";
+    const fullUrl = `${baseUrl}${normalizedPath}`;
+    const hasDoubleApi = fullUrl.includes("/api/api");
+    logTest(
+      "Path normalization prevents /api/api",
+      !hasDoubleApi,
+      `Full URL: ${fullUrl}`
+    );
+  }
+
+  // Test 4: Initialize CredentialManager
+  log("\n--- Test 4: CredentialManager Initialization ---");
+  const credentialManager = new CredentialManager();
+  await credentialManager.initialize();
+
+  const authMode = credentialManager.getAuthMode();
+  const isAuthenticated = credentialManager.isAuthenticated();
+  logTest(
+    "CredentialManager initialized",
+    authMode !== AuthMode.NONE && isAuthenticated,
+    `Auth mode: ${authMode}, Authenticated: ${isAuthenticated}`
+  );
+
+  // Test 5: Make actual API call
+  log("\n--- Test 5: Live API Call ---");
+  try {
+    const httpClient = createHttpClient(credentialManager);
+
+    // Use normalizePath to strip /api prefix (simulating what handlers.ts does now)
+    const apiPath = buildApiPath("namespace", "system");
+    const normalizedApiPath = apiPath ? normalizePath(apiPath) : "/web/namespaces";
+
+    log(`   Making request to: ${normalizedApiPath}`);
+    const response = await httpClient.get(normalizedApiPath);
+
+    const hasItems = response.data && (Array.isArray(response.data.items) || response.data.items !== undefined);
+    logTest(
+      "Live API call succeeded",
+      response.status === 200,
+      `Status: ${response.status}, Has items: ${hasItems}`
+    );
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+
+    // Check if error is due to /api/api (the bug we're fixing)
+    if (errorMsg.includes("/api/api") || errorMsg.includes("404")) {
+      logTest("Live API call succeeded", false, `ERROR: ${errorMsg} - Possible /api/api duplication!`);
+    } else if (errorMsg.includes("401") || errorMsg.includes("403")) {
+      // Auth errors are expected if token is invalid/expired, but URL is correct
+      logTest("Live API call (auth check)", true, `Got auth error (URL is correct): ${errorMsg}`);
+    } else {
+      logTest("Live API call succeeded", false, `ERROR: ${errorMsg}`);
+    }
+  }
+
+  // Test 6: Test with different URL format via environment
+  log("\n--- Test 6: URL Format Variations via Env ---");
+  const testFormats = [
+    "f5-amer-ent.console.ves.volterra.io",
+    "f5-amer-ent.console.ves.volterra.io/api",
+  ];
+
+  for (const testUrl of testFormats) {
+    const normalized = normalizeF5XCUrl(testUrl);
+    const endsWithApi = normalized.endsWith("/api");
+    logTest(
+      `URL ${testUrl} normalized correctly`,
+      !endsWithApi,
+      `Normalized to: ${normalized} (no trailing /api: ${!endsWithApi})`
+    );
+  }
+
+  // Summary
+  log("\n" + "=" .repeat(60));
+  log("VALIDATION SUMMARY");
+  log("=" .repeat(60));
+
+  const passed = results.filter(r => r.passed).length;
+  const failed = results.filter(r => !r.passed).length;
+  const total = results.length;
+
+  log(`\nTotal: ${total} tests`);
+  log(`Passed: ${passed}`);
+  log(`Failed: ${failed}`);
+
+  if (failed > 0) {
+    log("\nFailed tests:");
+    results.filter(r => !r.passed).forEach(r => {
+      log(`  - ${r.name}: ${r.details}`);
+    });
+    process.exit(1);
+  } else {
+    log("\n✅ All validation tests passed!");
+    process.exit(0);
+  }
+}
+
+runValidation().catch(err => {
+  console.error("Validation failed:", err);
+  process.exit(1);
+});

--- a/src/resources/handlers.ts
+++ b/src/resources/handlers.ts
@@ -16,6 +16,7 @@ import {
 import { CredentialManager, AuthMode, HttpClient } from "@robinmordasiewicz/f5xc-auth";
 import { logger } from "../utils/logging.js";
 import { F5XCApiError } from "../utils/error-handling.js";
+import { normalizePath } from "../utils/url-utils.js";
 
 /**
  * Resource read result
@@ -259,7 +260,8 @@ export class ResourceHandler {
     }
 
     try {
-      const response = await this.httpClient.get(apiPath);
+      // Use normalizePath to strip /api prefix since httpClient baseURL already includes /api
+      const response = await this.httpClient.get(normalizePath(apiPath));
 
       return {
         uri,
@@ -336,7 +338,8 @@ export class ResourceHandler {
     }
 
     try {
-      const response = await this.httpClient.get(apiPath);
+      // Use normalizePath to strip /api prefix since httpClient baseURL already includes /api
+      const response = await this.httpClient.get(normalizePath(apiPath));
 
       return {
         uri,

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import {
   createHttpClient,
 } from "@robinmordasiewicz/f5xc-auth";
 import { logger } from "./utils/logging.js";
+import { normalizeF5XCUrl } from "./utils/url-utils.js";
 import { VERSION } from "./index.js";
 import {
   getWorkflowPrompts,
@@ -1139,6 +1140,20 @@ export class F5XCApiServer {
  * 3. No credentials - documentation mode (lowest priority)
  */
 export async function createServer(): Promise<F5XCApiServer> {
+  // Normalize F5XC_API_URL environment variable before CredentialManager reads it
+  // This handles various URL formats users might provide:
+  // - Protocol-less URLs: tenant.console.ves.volterra.io
+  // - URLs with /api suffix: https://tenant.console.ves.volterra.io/api
+  // - Combinations of the above
+  const apiUrl = process.env.F5XC_API_URL;
+  if (apiUrl) {
+    const normalizedUrl = normalizeF5XCUrl(apiUrl);
+    if (normalizedUrl !== apiUrl) {
+      logger.info(`Normalizing F5XC_API_URL: ${apiUrl} -> ${normalizedUrl}`);
+      process.env.F5XC_API_URL = normalizedUrl;
+    }
+  }
+
   const credentialManager = new CredentialManager();
   await credentialManager.initialize();
 

--- a/src/tools/configure-auth.ts
+++ b/src/tools/configure-auth.ts
@@ -14,6 +14,8 @@ import {
   type CredentialManager,
   type Profile,
 } from "@robinmordasiewicz/f5xc-auth";
+import { normalizeF5XCUrl, verifyF5XCEndpoint } from "../utils/url-utils.js";
+import { logger } from "../utils/logging.js";
 
 /**
  * Tool name constant
@@ -36,13 +38,20 @@ export const configureAuthSchema = {
   tenantUrl: z
     .string()
     .optional()
-    .describe("F5XC tenant URL (e.g., https://tenant.console.ves.volterra.io)"),
+    .describe(
+      "F5XC tenant URL. Accepts various formats: https://tenant.console.ves.volterra.io, tenant.console.ves.volterra.io, tenant.staging.volterra.us, or even just the tenant name"
+    ),
   apiToken: z.string().optional().describe("API token for authentication"),
   profileName: z
     .string()
     .optional()
     .default("default")
     .describe("Profile name (default: 'default')"),
+  skipVerification: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe("Skip URL verification (useful for air-gapped environments)"),
 };
 
 /**
@@ -91,6 +100,7 @@ export async function handleConfigureAuth(
     tenantUrl?: string;
     apiToken?: string;
     profileName?: string;
+    skipVerification?: boolean;
   },
   credentialManager: CredentialManager
 ): Promise<ToolResponse> {
@@ -171,11 +181,12 @@ async function handleConfigure(
     tenantUrl?: string;
     apiToken?: string;
     profileName?: string;
+    skipVerification?: boolean;
   },
   credentialManager: CredentialManager,
   profileManager: ReturnType<typeof getProfileManager>
 ): Promise<ConfigureResponse> {
-  const { tenantUrl, apiToken, profileName = "default" } = args;
+  const { tenantUrl, apiToken, profileName = "default", skipVerification = false } = args;
 
   // Validate required fields
   if (!tenantUrl) {
@@ -194,10 +205,35 @@ async function handleConfigure(
     };
   }
 
-  // Create profile object
+  // Normalize URL to consistent format
+  const normalizedUrl = normalizeF5XCUrl(tenantUrl);
+  logger.info(`Normalizing URL: ${tenantUrl} -> ${normalizedUrl}`);
+
+  // Verify URL is accessible (unless skipped)
+  if (!skipVerification) {
+    logger.info(`Verifying URL accessibility: ${normalizedUrl}`);
+    const verification = await verifyF5XCEndpoint(normalizedUrl);
+
+    if (!verification.valid) {
+      let message = `URL verification failed for "${tenantUrl}": ${verification.error}`;
+      if (verification.suggestions?.length) {
+        message += `\n\nSuggestions:\n${verification.suggestions.map((s) => `  - ${s}`).join("\n")}`;
+      }
+      message += "\n\nUse skipVerification=true to bypass this check.";
+      return {
+        success: false,
+        profileName,
+        message,
+      };
+    }
+
+    logger.info(`URL verification successful: ${verification.normalizedUrl}`);
+  }
+
+  // Create profile object with normalized URL
   const profile: Profile = {
     name: profileName,
-    apiUrl: tenantUrl,
+    apiUrl: normalizedUrl,
     apiToken,
   };
 
@@ -229,7 +265,7 @@ async function handleConfigure(
   return {
     success: true,
     profileName,
-    message: `Credentials saved to profile '${profileName}' and set as active. API execution is now enabled.`,
+    message: `Credentials saved to profile '${profileName}' and set as active. URL normalized to: ${normalizedUrl}. API execution is now enabled.`,
   };
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,3 +18,12 @@ export {
   formatErrorForMcp,
   withErrorHandling,
 } from "./error-handling.js";
+
+export {
+  normalizePath,
+  normalizeF5XCUrl,
+  extractTenantFromUrl,
+  verifyF5XCEndpoint,
+  verifyWithRetry,
+} from "./url-utils.js";
+export type { UrlVerificationResult } from "./url-utils.js";

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,0 +1,315 @@
+/**
+ * URL Normalization Utilities for F5 Distributed Cloud
+ *
+ * Handles various URL formats users might enter and normalizes them
+ * to a consistent format that works with the F5XC API.
+ */
+
+import { logger } from "./logging.js";
+
+/**
+ * Strip /api prefix from paths to prevent /api/api duplication
+ * when used with HTTP client that has /api in baseURL.
+ *
+ * The F5XC API client sets baseURL to include /api, so paths
+ * from resource templates that include /api need to be normalized.
+ *
+ * @param path - API path that may contain /api prefix
+ * @returns Path with /api prefix removed if present
+ *
+ * @example
+ * normalizePath('/api/config/namespaces/default') // '/config/namespaces/default'
+ * normalizePath('/config/namespaces/default') // '/config/namespaces/default'
+ */
+export function normalizePath(path: string): string {
+  if (path.startsWith("/api/")) {
+    return path.slice(4); // Remove '/api', keep the leading '/'
+  }
+  return path;
+}
+
+/**
+ * Normalize F5XC tenant URL to consistent format.
+ *
+ * Handles various input formats:
+ * - Protocol-less URLs: tenant.console.ves.volterra.io
+ * - URLs with /api suffix: https://tenant.console.ves.volterra.io/api
+ * - Trailing slashes: https://tenant.console.ves.volterra.io/
+ * - Various domain patterns (staging, production, console)
+ *
+ * @param input - User-provided URL in any supported format
+ * @returns Normalized URL without /api suffix (httpClient adds it)
+ *
+ * @example
+ * normalizeF5XCUrl('tenant.console.ves.volterra.io')
+ * // 'https://tenant.console.ves.volterra.io'
+ *
+ * normalizeF5XCUrl('https://tenant.console.ves.volterra.io/api')
+ * // 'https://tenant.console.ves.volterra.io'
+ *
+ * normalizeF5XCUrl('tenant.staging.volterra.us/api/')
+ * // 'https://tenant.staging.volterra.us'
+ */
+export function normalizeF5XCUrl(input: string): string {
+  let url = input.trim();
+
+  // Handle empty string
+  if (!url) {
+    return "";
+  }
+
+  // Add https:// protocol if missing
+  if (!url.match(/^https?:\/\//i)) {
+    url = `https://${url}`;
+  }
+
+  // Remove trailing slashes
+  url = url.replace(/\/+$/, "");
+
+  // Remove /api suffix (case-insensitive) - httpClient will add it
+  url = url.replace(/\/api$/i, "");
+
+  // Validate it's a proper URL
+  try {
+    const parsed = new URL(url);
+    // Reconstruct to ensure consistency
+    return `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ""}`;
+  } catch {
+    // If URL parsing fails, return the cleaned input
+    logger.warn(`Could not parse URL: ${input}, returning cleaned input`);
+    return url;
+  }
+}
+
+/**
+ * Extract tenant name from F5XC URL
+ *
+ * @param url - Normalized or raw F5XC URL
+ * @returns Tenant name or null if not extractable
+ */
+export function extractTenantFromUrl(url: string): string | null {
+  try {
+    const normalized = normalizeF5XCUrl(url);
+    const parsed = new URL(normalized);
+    const hostname = parsed.hostname.toLowerCase();
+
+    // Match first subdomain as tenant
+    const match = hostname.match(/^([^.]+)\./);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Result of URL verification
+ */
+export interface UrlVerificationResult {
+  /** Whether the URL is valid and accessible */
+  valid: boolean;
+  /** Normalized URL */
+  normalizedUrl: string;
+  /** Extracted tenant name */
+  tenant: string | null;
+  /** Error message if invalid */
+  error?: string;
+  /** Suggestions for fixing the URL */
+  suggestions?: string[];
+}
+
+/**
+ * Verify F5XC API endpoint is accessible.
+ *
+ * Tests the URL by making a request to the /api endpoint.
+ * - 401/403 response = URL is valid (needs authentication)
+ * - 2xx response = URL is valid (unexpected but ok)
+ * - Network error = URL is invalid or unreachable
+ *
+ * @param url - URL to verify (will be normalized)
+ * @param options - Verification options
+ * @returns Verification result with status and suggestions
+ */
+export async function verifyF5XCEndpoint(
+  url: string,
+  options: { timeoutMs?: number; skipVerification?: boolean } = {}
+): Promise<UrlVerificationResult> {
+  const { timeoutMs = 10000, skipVerification = false } = options;
+
+  const normalizedUrl = normalizeF5XCUrl(url);
+  const tenant = extractTenantFromUrl(normalizedUrl);
+
+  // If verification is skipped, just return the normalized URL
+  if (skipVerification) {
+    return {
+      valid: true,
+      normalizedUrl,
+      tenant,
+    };
+  }
+
+  const apiUrl = `${normalizedUrl}/api`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(apiUrl, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    // 401/403 = URL is valid, just needs authentication
+    if (response.status === 401 || response.status === 403) {
+      return {
+        valid: true,
+        normalizedUrl,
+        tenant,
+      };
+    }
+
+    // 404 = Wrong URL format or path
+    if (response.status === 404) {
+      return {
+        valid: false,
+        normalizedUrl,
+        tenant,
+        error: "API endpoint not found (404). Verify the tenant URL format.",
+        suggestions: tenant
+          ? [
+              `Try: https://${tenant}.console.ves.volterra.io`,
+              `Try: https://${tenant}.staging.volterra.us`,
+            ]
+          : ["Verify the tenant name is correct"],
+      };
+    }
+
+    // Other successful responses - URL is valid
+    if (response.ok) {
+      return {
+        valid: true,
+        normalizedUrl,
+        tenant,
+      };
+    }
+
+    // Other error responses
+    return {
+      valid: false,
+      normalizedUrl,
+      tenant,
+      error: `Unexpected response: HTTP ${response.status}`,
+      suggestions: ["Verify the tenant URL and check F5XC console status"],
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Handle abort/timeout
+    if (errorMessage.includes("abort") || errorMessage.includes("timeout")) {
+      return {
+        valid: false,
+        normalizedUrl,
+        tenant,
+        error: `Connection timed out after ${timeoutMs}ms`,
+        suggestions: [
+          "Check network connectivity",
+          "Verify the F5XC console is accessible",
+          "Try increasing timeout if on slow network",
+        ],
+      };
+    }
+
+    // Handle SSL/TLS errors
+    if (
+      errorMessage.includes("certificate") ||
+      errorMessage.includes("SSL") ||
+      errorMessage.includes("TLS")
+    ) {
+      return {
+        valid: false,
+        normalizedUrl,
+        tenant,
+        error: `SSL/TLS error: ${errorMessage}`,
+        suggestions: [
+          "For staging environments, you may need to configure TLS settings",
+          "Verify the tenant URL is correct",
+        ],
+      };
+    }
+
+    // Handle DNS/network errors
+    if (
+      errorMessage.includes("ENOTFOUND") ||
+      errorMessage.includes("getaddrinfo") ||
+      errorMessage.includes("resolve")
+    ) {
+      return {
+        valid: false,
+        normalizedUrl,
+        tenant,
+        error: `Could not resolve hostname: ${errorMessage}`,
+        suggestions: tenant
+          ? [
+              `Verify tenant name "${tenant}" is correct`,
+              `Try: https://${tenant}.console.ves.volterra.io`,
+              "Check DNS resolution and network connectivity",
+            ]
+          : ["Verify the hostname is correct", "Check DNS resolution"],
+      };
+    }
+
+    // Generic connection error
+    return {
+      valid: false,
+      normalizedUrl,
+      tenant,
+      error: `Connection failed: ${errorMessage}`,
+      suggestions: [
+        "Verify the tenant URL is correct",
+        "Check network connectivity",
+        "Ensure the F5XC console is accessible",
+      ],
+    };
+  }
+}
+
+/**
+ * Verify URL with retry using different URL patterns.
+ *
+ * If the initial URL fails, tries common F5XC URL patterns
+ * based on the extracted tenant name.
+ *
+ * @param input - User-provided URL or tenant name
+ * @param options - Verification options
+ * @returns Best verification result from tried patterns
+ */
+export async function verifyWithRetry(
+  input: string,
+  options: { timeoutMs?: number } = {}
+): Promise<UrlVerificationResult> {
+  // Try the original input first
+  let result = await verifyF5XCEndpoint(input, options);
+  if (result.valid) return result;
+
+  // If input looks like just a tenant name (no dots), try common patterns
+  if (!input.includes(".")) {
+    const patterns = [
+      `${input}.console.ves.volterra.io`,
+      `${input}.staging.volterra.us`,
+      `${input}.volterra.us`,
+    ];
+
+    for (const pattern of patterns) {
+      result = await verifyF5XCEndpoint(pattern, options);
+      if (result.valid) {
+        logger.info(`URL verified using pattern: ${pattern}`);
+        return result;
+      }
+    }
+  }
+
+  // Return the last result with accumulated suggestions
+  return result;
+}

--- a/tests/acceptance/url-normalization.test.ts
+++ b/tests/acceptance/url-normalization.test.ts
@@ -1,0 +1,302 @@
+/**
+ * URL Normalization Acceptance Tests
+ *
+ * Tests that various URL input formats are correctly normalized
+ * and that the /api/api duplication issue is prevented.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CredentialManager, AuthMode } from "@robinmordasiewicz/f5xc-auth";
+import { handleConfigureAuth } from "../../src/tools/configure-auth.js";
+import { normalizePath, normalizeF5XCUrl } from "../../src/utils/url-utils.js";
+import { buildApiPath } from "../../src/resources/templates.js";
+
+describe("URL Normalization Acceptance Tests", () => {
+  describe("URL Format Variations", () => {
+    const urlVariations = [
+      {
+        input: "https://f5-amer-ent.console.ves.volterra.io",
+        expected: "https://f5-amer-ent.console.ves.volterra.io",
+        description: "standard console URL",
+      },
+      {
+        input: "https://f5-amer-ent.console.ves.volterra.io/api",
+        expected: "https://f5-amer-ent.console.ves.volterra.io",
+        description: "console URL with /api suffix",
+      },
+      {
+        input: "f5-amer-ent.console.ves.volterra.io",
+        expected: "https://f5-amer-ent.console.ves.volterra.io",
+        description: "console URL without protocol",
+      },
+      {
+        input: "f5-amer-ent.console.ves.volterra.io/api",
+        expected: "https://f5-amer-ent.console.ves.volterra.io",
+        description: "console URL without protocol, with /api",
+      },
+      {
+        input: "https://nferreira.staging.volterra.us",
+        expected: "https://nferreira.staging.volterra.us",
+        description: "staging URL",
+      },
+      {
+        input: "https://nferreira.staging.volterra.us/api",
+        expected: "https://nferreira.staging.volterra.us",
+        description: "staging URL with /api suffix",
+      },
+      {
+        input: "nferreira.staging.volterra.us",
+        expected: "https://nferreira.staging.volterra.us",
+        description: "staging URL without protocol",
+      },
+      {
+        input: "nferreira.staging.volterra.us/api",
+        expected: "https://nferreira.staging.volterra.us",
+        description: "staging URL without protocol, with /api",
+      },
+      {
+        input: "  f5-amer-ent.console.ves.volterra.io  ",
+        expected: "https://f5-amer-ent.console.ves.volterra.io",
+        description: "URL with leading/trailing whitespace",
+      },
+      {
+        input: "https://f5-amer-ent.console.ves.volterra.io///",
+        expected: "https://f5-amer-ent.console.ves.volterra.io",
+        description: "URL with multiple trailing slashes",
+      },
+      {
+        input: "https://f5-amer-ent.console.ves.volterra.io/api/",
+        expected: "https://f5-amer-ent.console.ves.volterra.io",
+        description: "URL with /api/ (trailing slash)",
+      },
+    ];
+
+    it.each(urlVariations)(
+      "should normalize $description: $input -> $expected",
+      ({ input, expected }) => {
+        expect(normalizeF5XCUrl(input)).toBe(expected);
+      }
+    );
+  });
+
+  describe("Path Normalization Prevents /api/api Duplication", () => {
+    const resourceTypes = [
+      "namespace",
+      "certificate",
+      "http_loadbalancer",
+      "origin_pool",
+      "dns_zone",
+      "app_firewall",
+    ];
+
+    it.each(resourceTypes)(
+      "should prevent /api/api for resource type: %s",
+      (resourceType: string) => {
+        const namespace = "default";
+        const apiPath = buildApiPath(resourceType, namespace);
+
+        // Skip if resource type doesn't exist in templates
+        if (!apiPath) {
+          return;
+        }
+
+        // The apiPath from templates includes /api prefix
+        expect(apiPath.startsWith("/api/")).toBe(true);
+
+        // After normalization, it should not start with /api
+        const normalizedPath = normalizePath(apiPath);
+        expect(normalizedPath.startsWith("/api/")).toBe(false);
+
+        // Simulated full URL construction
+        const baseUrl = "https://tenant.console.ves.volterra.io/api";
+        const fullUrl = `${baseUrl}${normalizedPath}`;
+
+        // Should never have /api/api
+        expect(fullUrl).not.toContain("/api/api");
+
+        // Should have exactly one /api
+        const apiCount = (fullUrl.match(/\/api/g) ?? []).length;
+        expect(apiCount).toBe(1);
+      }
+    );
+  });
+
+  describe("Configure Auth URL Normalization", () => {
+    let mockCredentialManager: CredentialManager;
+
+    beforeEach(async () => {
+      // Mock fetch to avoid network calls during verification
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 401, ok: false }));
+
+      mockCredentialManager = new CredentialManager();
+      await mockCredentialManager.initialize();
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should normalize URL when configuring with protocol-less URL", async () => {
+      const result = await handleConfigureAuth(
+        {
+          action: "configure",
+          tenantUrl: "f5-amer-ent.console.ves.volterra.io",
+          apiToken: "test-token",
+          profileName: "test-profile",
+          skipVerification: true,
+        },
+        mockCredentialManager
+      );
+
+      expect(result).toHaveProperty("success", true);
+      expect(result).toHaveProperty("message");
+      expect((result as { message: string }).message).toContain(
+        "https://f5-amer-ent.console.ves.volterra.io"
+      );
+    });
+
+    it("should normalize URL when configuring with /api suffix", async () => {
+      const result = await handleConfigureAuth(
+        {
+          action: "configure",
+          tenantUrl: "https://f5-amer-ent.console.ves.volterra.io/api",
+          apiToken: "test-token",
+          profileName: "test-profile",
+          skipVerification: true,
+        },
+        mockCredentialManager
+      );
+
+      expect(result).toHaveProperty("success", true);
+      expect(result).toHaveProperty("message");
+      // The message should show normalized URL without /api
+      expect((result as { message: string }).message).toContain(
+        "https://f5-amer-ent.console.ves.volterra.io"
+      );
+      expect((result as { message: string }).message).not.toContain("/api/api");
+    });
+
+    it("should verify URL when skipVerification is false", async () => {
+      await handleConfigureAuth(
+        {
+          action: "configure",
+          tenantUrl: "f5-amer-ent.console.ves.volterra.io",
+          apiToken: "test-token",
+          profileName: "test-profile",
+          skipVerification: false,
+        },
+        mockCredentialManager
+      );
+
+      // Should have called fetch for verification
+      expect(fetch).toHaveBeenCalledWith(
+        "https://f5-amer-ent.console.ves.volterra.io/api",
+        expect.any(Object)
+      );
+    });
+
+    it("should not verify URL when skipVerification is true", async () => {
+      await handleConfigureAuth(
+        {
+          action: "configure",
+          tenantUrl: "f5-amer-ent.console.ves.volterra.io",
+          apiToken: "test-token",
+          profileName: "test-profile",
+          skipVerification: true,
+        },
+        mockCredentialManager
+      );
+
+      // Should not have called fetch
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return error with suggestions when URL verification fails", async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error("ENOTFOUND: getaddrinfo failed"));
+
+      const result = await handleConfigureAuth(
+        {
+          action: "configure",
+          tenantUrl: "invalid-tenant.console.ves.volterra.io",
+          apiToken: "test-token",
+          profileName: "test-profile",
+          skipVerification: false,
+        },
+        mockCredentialManager
+      );
+
+      expect(result).toHaveProperty("success", false);
+      expect(result).toHaveProperty("message");
+      expect((result as { message: string }).message).toContain("verification failed");
+      expect((result as { message: string }).message).toContain("Suggestions");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle empty string gracefully", () => {
+      // Empty string should return https:// with empty host
+      const result = normalizeF5XCUrl("");
+      expect(result).toBe("");
+    });
+
+    it("should handle whitespace-only string", () => {
+      const result = normalizeF5XCUrl("   ");
+      expect(result).toBe("");
+    });
+
+    it("should normalize path with only /api", () => {
+      expect(normalizePath("/api")).toBe("/api");
+      expect(normalizePath("/api/")).toBe("/");
+    });
+
+    it("should preserve query parameters in URL", () => {
+      // Note: our normalizeF5XCUrl strips query params since F5XC base URLs shouldn't have them
+      // This is intentional behavior - query params belong on API paths, not base URLs
+      const result = normalizeF5XCUrl("https://tenant.console.ves.volterra.io?foo=bar");
+      expect(result).toBe("https://tenant.console.ves.volterra.io");
+    });
+  });
+
+  describe("Real-World URL Patterns from User Reports", () => {
+    // These test cases are based on actual user-reported URL formats
+    const userReportedPatterns = [
+      {
+        input: "https://nferreira.staging.volterra.us",
+        description: "Staging environment (user format 1)",
+      },
+      {
+        input: "https://nferreira.staging.volterra.us/api",
+        description: "Staging environment with /api (user format 2)",
+      },
+      {
+        input: "nferreira.staging.volterra.us",
+        description: "Staging without protocol (user format 3)",
+      },
+      {
+        input: "nferreira.staging.volterra.us/api",
+        description: "Staging without protocol, with /api (user format 4)",
+      },
+    ];
+
+    it.each(userReportedPatterns)(
+      "should handle $description without causing /api/api",
+      ({ input }) => {
+        // Normalize the URL
+        const normalizedUrl = normalizeF5XCUrl(input);
+
+        // Should have https://
+        expect(normalizedUrl.startsWith("https://")).toBe(true);
+
+        // Should not end with /api
+        expect(normalizedUrl.endsWith("/api")).toBe(false);
+
+        // When used with a resource path, should not have /api/api
+        const resourcePath = "/api/config/namespaces/default/http_loadbalancers";
+        const normalizedPath = normalizePath(resourcePath);
+        const fullUrl = `${normalizedUrl}/api${normalizedPath}`;
+
+        expect(fullUrl).not.toContain("/api/api");
+      }
+    );
+  });
+});

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -1,0 +1,366 @@
+/**
+ * URL Utilities Unit Tests
+ *
+ * Tests for URL normalization and path handling functions
+ * that prevent /api/api duplication errors.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  normalizePath,
+  normalizeF5XCUrl,
+  extractTenantFromUrl,
+  verifyF5XCEndpoint,
+  verifyWithRetry,
+} from "../../src/utils/url-utils.js";
+
+describe("URL Utilities", () => {
+  describe("normalizePath", () => {
+    it("should strip /api prefix from paths", () => {
+      expect(normalizePath("/api/config/namespaces/default")).toBe("/config/namespaces/default");
+    });
+
+    it("should strip /api prefix from paths with resource names", () => {
+      expect(normalizePath("/api/config/namespaces/default/http_loadbalancers/my-lb")).toBe(
+        "/config/namespaces/default/http_loadbalancers/my-lb"
+      );
+    });
+
+    it("should preserve paths without /api prefix", () => {
+      expect(normalizePath("/config/namespaces/default")).toBe("/config/namespaces/default");
+    });
+
+    it("should handle paths that start with /api without trailing content", () => {
+      expect(normalizePath("/api/")).toBe("/");
+    });
+
+    it("should not modify paths that contain api elsewhere", () => {
+      expect(normalizePath("/config/api-gateway/default")).toBe("/config/api-gateway/default");
+    });
+
+    it("should handle root path", () => {
+      expect(normalizePath("/")).toBe("/");
+    });
+
+    it("should handle empty string", () => {
+      expect(normalizePath("")).toBe("");
+    });
+
+    it("should not strip /api if it's not at the start", () => {
+      expect(normalizePath("/v1/api/config")).toBe("/v1/api/config");
+    });
+  });
+
+  describe("normalizeF5XCUrl", () => {
+    describe("protocol handling", () => {
+      it("should add https:// to protocol-less URLs", () => {
+        expect(normalizeF5XCUrl("tenant.console.ves.volterra.io")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+
+      it("should preserve existing https:// protocol", () => {
+        expect(normalizeF5XCUrl("https://tenant.console.ves.volterra.io")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+
+      it("should preserve http:// protocol (even though not recommended)", () => {
+        expect(normalizeF5XCUrl("http://tenant.console.ves.volterra.io")).toBe(
+          "http://tenant.console.ves.volterra.io"
+        );
+      });
+    });
+
+    describe("/api suffix handling", () => {
+      it("should remove /api suffix", () => {
+        expect(normalizeF5XCUrl("https://tenant.console.ves.volterra.io/api")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+
+      it("should remove /api suffix from protocol-less URLs", () => {
+        expect(normalizeF5XCUrl("tenant.console.ves.volterra.io/api")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+
+      it("should handle /api/ with trailing slash", () => {
+        expect(normalizeF5XCUrl("https://tenant.console.ves.volterra.io/api/")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+
+      it("should handle case-insensitive /API suffix", () => {
+        expect(normalizeF5XCUrl("https://tenant.console.ves.volterra.io/API")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+    });
+
+    describe("trailing slash handling", () => {
+      it("should remove single trailing slash", () => {
+        expect(normalizeF5XCUrl("https://tenant.console.ves.volterra.io/")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+
+      it("should remove multiple trailing slashes", () => {
+        expect(normalizeF5XCUrl("https://tenant.console.ves.volterra.io///")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+    });
+
+    describe("staging URLs", () => {
+      it("should normalize staging URLs", () => {
+        expect(normalizeF5XCUrl("tenant.staging.volterra.us")).toBe(
+          "https://tenant.staging.volterra.us"
+        );
+      });
+
+      it("should normalize staging URLs with /api", () => {
+        expect(normalizeF5XCUrl("tenant.staging.volterra.us/api")).toBe(
+          "https://tenant.staging.volterra.us"
+        );
+      });
+
+      it("should normalize staging URLs with https", () => {
+        expect(normalizeF5XCUrl("https://tenant.staging.volterra.us")).toBe(
+          "https://tenant.staging.volterra.us"
+        );
+      });
+    });
+
+    describe("console URLs", () => {
+      it("should normalize console.ves.volterra.io URLs", () => {
+        expect(normalizeF5XCUrl("tenant.console.ves.volterra.io")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+
+      it("should normalize staging console URLs", () => {
+        expect(normalizeF5XCUrl("tenant.staging.console.ves.volterra.io")).toBe(
+          "https://tenant.staging.console.ves.volterra.io"
+        );
+      });
+    });
+
+    describe("whitespace handling", () => {
+      it("should trim leading/trailing whitespace", () => {
+        expect(normalizeF5XCUrl("  tenant.console.ves.volterra.io  ")).toBe(
+          "https://tenant.console.ves.volterra.io"
+        );
+      });
+    });
+
+    describe("port handling", () => {
+      it("should preserve explicit ports", () => {
+        expect(normalizeF5XCUrl("https://tenant.console.ves.volterra.io:8443")).toBe(
+          "https://tenant.console.ves.volterra.io:8443"
+        );
+      });
+    });
+  });
+
+  describe("extractTenantFromUrl", () => {
+    it("should extract tenant from console URL", () => {
+      expect(extractTenantFromUrl("https://f5-amer-ent.console.ves.volterra.io")).toBe(
+        "f5-amer-ent"
+      );
+    });
+
+    it("should extract tenant from staging URL", () => {
+      expect(extractTenantFromUrl("https://nferreira.staging.volterra.us")).toBe("nferreira");
+    });
+
+    it("should extract tenant from protocol-less URL", () => {
+      expect(extractTenantFromUrl("mytenant.console.ves.volterra.io")).toBe("mytenant");
+    });
+
+    it("should extract tenant from URL with /api suffix", () => {
+      expect(extractTenantFromUrl("https://mytenant.console.ves.volterra.io/api")).toBe("mytenant");
+    });
+
+    it("should return null for invalid URL", () => {
+      expect(extractTenantFromUrl("not-a-url")).toBe(null);
+    });
+
+    it("should handle hyphenated tenant names", () => {
+      expect(extractTenantFromUrl("https://my-tenant-name.console.ves.volterra.io")).toBe(
+        "my-tenant-name"
+      );
+    });
+  });
+
+  describe("verifyF5XCEndpoint", () => {
+    beforeEach(() => {
+      vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should return valid for 401 response (valid URL, needs auth)", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        status: 401,
+        ok: false,
+      } as Response);
+
+      const result = await verifyF5XCEndpoint("https://tenant.console.ves.volterra.io");
+
+      expect(result.valid).toBe(true);
+      expect(result.normalizedUrl).toBe("https://tenant.console.ves.volterra.io");
+      expect(result.tenant).toBe("tenant");
+    });
+
+    it("should return valid for 403 response (valid URL, needs auth)", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        status: 403,
+        ok: false,
+      } as Response);
+
+      const result = await verifyF5XCEndpoint("https://tenant.console.ves.volterra.io");
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return invalid for 404 response with suggestions", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        status: 404,
+        ok: false,
+      } as Response);
+
+      const result = await verifyF5XCEndpoint("https://tenant.console.ves.volterra.io");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("404");
+      expect(result.suggestions).toBeDefined();
+      expect(result.suggestions!.length).toBeGreaterThan(0);
+    });
+
+    it("should return invalid for network error with suggestions", async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error("ENOTFOUND: getaddrinfo failed"));
+
+      const result = await verifyF5XCEndpoint("https://invalid.console.ves.volterra.io");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("Could not resolve hostname");
+      expect(result.suggestions).toBeDefined();
+    });
+
+    it("should return invalid for timeout", async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error("aborted"));
+
+      const result = await verifyF5XCEndpoint("https://tenant.console.ves.volterra.io", {
+        timeoutMs: 1000,
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("timed out");
+    });
+
+    it("should skip verification when skipVerification is true", async () => {
+      const result = await verifyF5XCEndpoint("https://tenant.console.ves.volterra.io", {
+        skipVerification: true,
+      });
+
+      expect(result.valid).toBe(true);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("should normalize URL before verification", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        status: 401,
+        ok: false,
+      } as Response);
+
+      const result = await verifyF5XCEndpoint("tenant.console.ves.volterra.io/api");
+
+      expect(result.normalizedUrl).toBe("https://tenant.console.ves.volterra.io");
+      expect(fetch).toHaveBeenCalledWith(
+        "https://tenant.console.ves.volterra.io/api",
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe("verifyWithRetry", () => {
+    beforeEach(() => {
+      vi.stubGlobal("fetch", vi.fn());
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("should return immediately if first attempt succeeds", async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        status: 401,
+        ok: false,
+      } as Response);
+
+      const result = await verifyWithRetry("https://tenant.console.ves.volterra.io");
+
+      expect(result.valid).toBe(true);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should try common patterns for tenant-only input", async () => {
+      // First call fails, second succeeds
+      vi.mocked(fetch)
+        .mockRejectedValueOnce(new Error("ENOTFOUND"))
+        .mockResolvedValueOnce({
+          status: 401,
+          ok: false,
+        } as Response);
+
+      const result = await verifyWithRetry("mytenant");
+
+      expect(result.valid).toBe(true);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Integration: normalizePath with buildApiPath patterns", () => {
+    // These test cases ensure that the combination of resource template paths
+    // and normalizePath prevents /api/api duplication
+
+    const resourcePaths = [
+      "/api/web/namespaces",
+      "/api/config/namespaces/{namespace}/certificates",
+      "/api/config/namespaces/{namespace}/http_loadbalancers",
+      "/api/config/namespaces/{namespace}/origin_pools",
+      "/api/config/namespaces/{namespace}/dns_zones",
+      "/api/config/namespaces/{namespace}/app_firewalls",
+    ];
+
+    it.each(resourcePaths)(
+      "should correctly normalize resource path: %s",
+      (resourcePath: string) => {
+        const normalizedPath = normalizePath(resourcePath);
+        const baseUrl = "https://tenant.console.ves.volterra.io/api";
+        const fullUrl = `${baseUrl}${normalizedPath}`;
+
+        // Should never have /api/api
+        expect(fullUrl).not.toContain("/api/api");
+
+        // Should have exactly one /api
+        const apiCount = (fullUrl.match(/\/api/g) ?? []).length;
+        expect(apiCount).toBe(1);
+      }
+    );
+
+    it("should construct correct URL from baseUrl + normalized path", () => {
+      const baseUrl = "https://tenant.console.ves.volterra.io/api";
+      const resourcePath = "/api/config/namespaces/default/http_loadbalancers";
+      const normalizedPath = normalizePath(resourcePath);
+      const fullUrl = `${baseUrl}${normalizedPath}`;
+
+      expect(fullUrl).toBe(
+        "https://tenant.console.ves.volterra.io/api/config/namespaces/default/http_loadbalancers"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #176 - Users entering URLs in various formats experienced 4xx errors due to `/api/api` path duplication.

## Problem

Users configure F5XC API URLs in various formats:
- `https://tenant.console.ves.volterra.io` (standard)
- `https://tenant.console.ves.volterra.io/api` (with /api suffix)
- `tenant.console.ves.volterra.io` (no protocol)
- `tenant.console.ves.volterra.io/api` (no protocol, with /api)

When these formats are passed to the httpClient (which has `/api` in its baseURL), it causes `/api/api` duplication resulting in 4xx errors.

## Solution

1. **URL Utilities Module** (`src/utils/url-utils.ts`):
   - `normalizeF5XCUrl()` - Normalizes tenant URLs (adds protocol, strips /api suffix)
   - `normalizePath()` - Strips /api prefix from API paths
   - `verifyF5XCEndpoint()` - Validates URL accessibility before saving

2. **Handler Fix** (`src/resources/handlers.ts`):
   - Uses `normalizePath()` before HTTP calls to prevent /api/api

3. **Server Initialization** (`src/server.ts`):
   - Normalizes `F5XC_API_URL` env var before CredentialManager reads it

4. **Configure Auth Enhancement** (`src/tools/configure-auth.ts`):
   - Normalizes URLs before saving profiles
   - Optional URL verification with helpful error messages

## Test Results

- 53 new tests (41 unit + 12 acceptance)
- All 1788 tests pass
- End-to-end validation with live API calls

Tested URL formats:
```
✅ https://f5-amer-ent.console.ves.volterra.io (standard)
✅ f5-amer-ent.console.ves.volterra.io/api (no protocol, with /api)
✅ tenant.staging.volterra.us (staging environment)
```

## Future Enhancement

Added `docs/f5xc-auth-enhancement-spec.md` proposing URL normalization be moved into the `@robinmordasiewicz/f5xc-auth` package for a "single source of truth" approach.

## Test plan

- [x] Unit tests for url-utils module
- [x] Acceptance tests for URL normalization
- [x] End-to-end validation with live API
- [x] Full test suite passes (1788 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)