### PR TITLE
chore(deps): update @robinmordasiewicz/f5xc-auth to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,9 +1623,9 @@
       }
     },
     "node_modules/@robinmordasiewicz/f5xc-auth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/f5xc-auth/-/f5xc-auth-1.0.0.tgz",
-      "integrity": "sha512-x1EGgy2XLqk2jPwSov5oTXCgjyHy4ZAtzUY9P//TO7AyHotOgeHAWIUSqKLUIjX10AgZrerY+a9ptY3C/0P3pA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/f5xc-auth/-/f5xc-auth-1.0.1.tgz",
+      "integrity": "sha512-FiVsajsnveHvk/zT5J98pv/1ma0gObSsBiJHoq27VYaxidV39vOn5pNwDWKyO3xgp0ysEjlBbAxn7kWZear3Qg==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.0",


### PR DESCRIPTION
## Summary
- Update @robinmordasiewicz/f5xc-auth dependency to v1.0.1

## Changes in f5xc-auth v1.0.1
- Enhanced `normalizeApiUrl()` with protocol handling (adds `https://` when missing)
- Enhanced `normalizeApiUrl()` with whitespace trimming
- Added new `normalizeTenantUrl()` export function
- Comprehensive unit tests (37 tests)

## Impact
This update makes f5xc-auth the single source of truth for URL normalization, supporting all input formats:
- `tenant.console.ves.volterra.io` → `https://tenant.console.ves.volterra.io/api`
- `https://tenant.console.ves.volterra.io` → `https://tenant.console.ves.volterra.io/api`
- `tenant.staging.volterra.us` → `https://tenant.staging.volterra.us/api`
- `  tenant.console.ves.volterra.io  ` → `https://tenant.console.ves.volterra.io/api`

## Test plan
- [x] All 1659 tests pass
- [x] TypeScript compilation successful
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)