### PR TITLE
fix: enable Material icons rendering in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,9 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
## Summary
- Add `pymdownx.emoji` extension to mkdocs.yml to enable Material Design Icons and GitHub Octicons rendering
- Fixes icon syntax like `:material-console:{ .lg .middle }` displaying as raw text instead of graphical icons

## Problem
The documentation at https://robinmordasiewicz.github.io/f5xc-api-mcp/#ide-support shows raw icon syntax instead of rendered icons.

## Solution
Enable the `pymdownx.emoji` extension with Material for MkDocs' built-in emoji/icon support:
- `emoji_index: material.extensions.emoji.twemoji`
- `emoji_generator: material.extensions.emoji.to_svg`

## Test plan
- [x] Build docs locally: `mkdocs build` completes successfully
- [ ] Verify icons render properly after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)