### PR TITLE
feat: migrate GitHub Pages deployment to gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,13 +16,7 @@ on:
       - "requirements.txt"
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  contents: write  # Need write access to push to gh-pages branch
 
 jobs:
   build:
@@ -64,25 +58,16 @@ jobs:
       - name: Build documentation
         run: mkdocs build --strict
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: ./site
-
-  deploy:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'docs: deploy ${{ github.sha }}'
 
   link-check:
     name: Check Links
@@ -94,25 +79,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
-        run: pip install linkchecker
-
-      - name: Download artifact
-        uses: actions/download-artifact@v6
+      - name: Cache pip
+        uses: actions/cache@v5
         with:
-          name: github-pages
-          path: ./site
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
 
-      - name: Extract artifact
-        run: |
-          cd site
-          tar -xvf artifact.tar
-          rm artifact.tar
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Generate documentation
+        run: npm run generate-docs
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt linkchecker
+
+      - name: Build documentation
+        run: mkdocs build --strict
 
       - name: Start local server
         run: |


### PR DESCRIPTION
## Summary
Migrates GitHub Pages deployment from artifact-based approach to branch-based deployment using `gh-pages` branch.

## Changes
- **Permissions**: Changed from `pages: write, id-token: write` to `contents: write`
- **Deployment**: Replace `actions/upload-pages-artifact` and `actions/deploy-pages` with `peaceiris/actions-gh-pages@v4`
- **Workflow simplification**: Removed separate deploy job, integrated deployment into build job
- **Link-check update**: Build site locally instead of downloading artifacts
- **Concurrency**: Removed unnecessary concurrency group

## Benefits
- Simpler workflow with fewer moving parts
- Deployment history visible in gh-pages branch
- Faster execution (no artifact upload/download overhead)
- Traditional GitHub Pages approach with branch-based deployment

## Post-Merge Steps
After this PR merges, GitHub Pages settings must be updated:
1. Go to: https://github.com/robinmordasiewicz/f5xc-api-mcp/settings/pages
2. Under "Build and deployment":
   - **Source**: Select "Deploy from a branch"
   - **Branch**: Select `gh-pages` and `/ (root)` directory
   - Click "Save"

## Testing Plan
- ✅ Pre-commit hooks passed
- ⏳ Workflow will run on merge to main
- ⏳ Verify gh-pages branch is created automatically
- ⏳ Verify site deploys correctly to https://robinmordasiewicz.github.io/f5xc-api-mcp
- ⏳ Verify link-check job works on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)