### PR TITLE
chore: update mkdocs and package metadata to MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Robin Mordasiewicz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 // @ts-check
 import eslint from "@eslint/js";
 import tseslint from "@typescript-eslint/eslint-plugin";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,7 +129,7 @@ extra:
     Integrations: int
     Cloud Resources: cloud
     BIG-IP Integration: bigip
-copyright: Copyright &copy; 2024 F5XC API MCP Server
+copyright: Copyright &copy; 2026 Robin Mordasiewicz. MIT License.
 nav:
   - Home: index.md
   - Getting Started:

--- a/scripts/category-mapping.ts
+++ b/scripts/category-mapping.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Category Mapping for Documentation Generation
  *

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 /**
  * Documentation Generation Script

--- a/scripts/generate-test-fixtures.ts
+++ b/scripts/generate-test-fixtures.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 /**
  * Dynamic Test Fixtures Generator

--- a/scripts/generate-version.ts
+++ b/scripts/generate-version.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Version Generator Script
  *

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 /**
  * Tool Generation Script

--- a/scripts/sync-specs.ts
+++ b/scripts/sync-specs.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 /**
  * OpenAPI Specification Sync Script

--- a/scripts/validate-auth-integration.ts
+++ b/scripts/validate-auth-integration.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env npx tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Auth Integration Validation Script
  *

--- a/scripts/validate-categories.ts
+++ b/scripts/validate-categories.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 /**
  * Validation script to verify domain title conversion and subdivision detection

--- a/scripts/validate-generation.ts
+++ b/scripts/validate-generation.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 /**
  * Validates that tool generation is consistent and complete

--- a/scripts/validate-url-fix.ts
+++ b/scripts/validate-url-fix.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env npx tsx
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * End-to-End Validation Script for URL Normalization Fix
  *

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Version Generator for F5 XC API MCP Server
  *

--- a/src/generator/dependency-extractor.ts
+++ b/src/generator/dependency-extractor.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Dependency Extractor
  *

--- a/src/generator/dependency-graph.ts
+++ b/src/generator/dependency-graph.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Dependency Graph Builder
  *

--- a/src/generator/dependency-types.ts
+++ b/src/generator/dependency-types.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Dependency Intelligence Type Definitions
  *

--- a/src/generator/domain-metadata.ts
+++ b/src/generator/domain-metadata.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Domain Metadata Module
  *

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Generator Module - Export all generator utilities
  */

--- a/src/generator/naming/acronyms.ts
+++ b/src/generator/naming/acronyms.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Acronym Normalization for F5XC API
  *

--- a/src/generator/naming/index.ts
+++ b/src/generator/naming/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Naming Module - Export all naming utilities
  *

--- a/src/generator/naming/volterra-mapping.ts
+++ b/src/generator/naming/volterra-mapping.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * F5XC Tool Naming Utilities
  *

--- a/src/generator/openapi-parser.ts
+++ b/src/generator/openapi-parser.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * OpenAPI Specification Parser
  *

--- a/src/generator/tool-generator.ts
+++ b/src/generator/tool-generator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * MCP Tool Generator
  *

--- a/src/generator/transformers/index.ts
+++ b/src/generator/transformers/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Transformers Module
  *

--- a/src/generator/transformers/normalize-examples.ts
+++ b/src/generator/transformers/normalize-examples.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Example Normalization Transformer
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
 
 /**
  * F5 Distributed Cloud API MCP Server

--- a/src/prompts/error-resolution.ts
+++ b/src/prompts/error-resolution.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Error Resolution Prompts (Phase B)
  *

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Prompts Module - Export all prompt utilities
  */

--- a/src/prompts/workflows.ts
+++ b/src/prompts/workflows.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * MCP Workflow Prompts
  *

--- a/src/resources/handlers.ts
+++ b/src/resources/handlers.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * MCP Resource Handlers
  *

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Resources Module - Export all resource utilities
  */

--- a/src/resources/templates.ts
+++ b/src/resources/templates.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * MCP Resource URI Templates
  *

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * F5 Distributed Cloud API MCP Server
  *

--- a/src/tools/configure-auth.ts
+++ b/src/tools/configure-auth.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Configure Auth Tool - MCP tool for authentication management
  *

--- a/src/tools/discovery/best-practices.ts
+++ b/src/tools/discovery/best-practices.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Best Practices Discovery
  *

--- a/src/tools/discovery/consolidate.ts
+++ b/src/tools/discovery/consolidate.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Resource Consolidation Module
  *

--- a/src/tools/discovery/cost-estimator.ts
+++ b/src/tools/discovery/cost-estimator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Cost and Performance Estimation
  *

--- a/src/tools/discovery/dependencies.ts
+++ b/src/tools/discovery/dependencies.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Dependency Discovery Module
  *

--- a/src/tools/discovery/describe.ts
+++ b/src/tools/discovery/describe.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Tool Description Loader
  *

--- a/src/tools/discovery/execute.ts
+++ b/src/tools/discovery/execute.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Tool Execution Dispatcher
  *

--- a/src/tools/discovery/index-loader.ts
+++ b/src/tools/discovery/index-loader.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Tool Index Loader
  *

--- a/src/tools/discovery/index.ts
+++ b/src/tools/discovery/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Discovery Module - Dynamic Tool Discovery for Token Efficiency
  *

--- a/src/tools/discovery/resolver.ts
+++ b/src/tools/discovery/resolver.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Interactive Dependency Resolver
  *

--- a/src/tools/discovery/schema-loader.ts
+++ b/src/tools/discovery/schema-loader.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Schema Loader Module
  *

--- a/src/tools/discovery/schema.ts
+++ b/src/tools/discovery/schema.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Schema Retrieval Module
  *

--- a/src/tools/discovery/search.ts
+++ b/src/tools/discovery/search.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Tool Search Implementation
  *

--- a/src/tools/discovery/suggest-params.ts
+++ b/src/tools/discovery/suggest-params.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Parameter Suggestion Module
  *

--- a/src/tools/discovery/types.ts
+++ b/src/tools/discovery/types.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Discovery Module Type Definitions
  *

--- a/src/tools/discovery/validate.ts
+++ b/src/tools/discovery/validate.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Parameter Validation Module (Phase B)
  *

--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /// <reference types="node" />
 /**
  * Error handling utilities for F5XC API MCP Server

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Utils Module - Export all utility functions
  */

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Logging utilities for F5XC API MCP Server
  *

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * URL Normalization Utilities for F5 Distributed Cloud
  *

--- a/tests/acceptance/api-endpoints.test.ts
+++ b/tests/acceptance/api-endpoints.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * API Endpoint Acceptance Tests
  *

--- a/tests/acceptance/auth-integration.test.ts
+++ b/tests/acceptance/auth-integration.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * End-to-End Auth Integration Tests
  *

--- a/tests/acceptance/url-normalization.test.ts
+++ b/tests/acceptance/url-normalization.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * URL Normalization Acceptance Tests
  *

--- a/tests/contract/mcp-protocol.test.ts
+++ b/tests/contract/mcp-protocol.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Contract tests for MCP protocol compliance
  *

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Global test setup
  *

--- a/tests/uat/chat-queries/authentication.test.ts
+++ b/tests/uat/chat-queries/authentication.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Authentication Query Tests
  *

--- a/tests/uat/chat-queries/creation.test.ts
+++ b/tests/uat/chat-queries/creation.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Creation Query Tests
  *

--- a/tests/uat/chat-queries/discovery.test.ts
+++ b/tests/uat/chat-queries/discovery.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Discovery Query Tests
  *

--- a/tests/uat/chat-queries/guidance.test.ts
+++ b/tests/uat/chat-queries/guidance.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Guidance Query Tests
  *

--- a/tests/uat/chat-queries/inspection.test.ts
+++ b/tests/uat/chat-queries/inspection.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Inspection Query Tests
  *

--- a/tests/uat/chat-queries/modification.test.ts
+++ b/tests/uat/chat-queries/modification.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Modification Query Tests
  *

--- a/tests/uat/chat-queries/planning.test.ts
+++ b/tests/uat/chat-queries/planning.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Planning Query Tests
  *

--- a/tests/uat/chat-queries/utils/query-helpers.ts
+++ b/tests/uat/chat-queries/utils/query-helpers.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Chat Query Simulation Helpers
  *

--- a/tests/uat/chat-queries/validation.test.ts
+++ b/tests/uat/chat-queries/validation.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Validation Query Tests
  *

--- a/tests/uat/documentation/cli-help.test.ts
+++ b/tests/uat/documentation/cli-help.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * CLI Help Text Validation Tests
  *

--- a/tests/uat/documentation/curl-examples.test.ts
+++ b/tests/uat/documentation/curl-examples.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * CURL Examples Validation Tests
  *

--- a/tests/uat/documentation/env-variables.test.ts
+++ b/tests/uat/documentation/env-variables.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Environment Variables Validation Tests
  *

--- a/tests/uat/documentation/installation-syntax.test.ts
+++ b/tests/uat/documentation/installation-syntax.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Installation Syntax Validation Tests
  *

--- a/tests/uat/documentation/manifest-prompts.test.ts
+++ b/tests/uat/documentation/manifest-prompts.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Manifest Prompts Validation Tests
  *

--- a/tests/uat/documentation/tool-descriptions.test.ts
+++ b/tests/uat/documentation/tool-descriptions.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Tool Descriptions Validation Tests
  *

--- a/tests/uat/utils/documentation-helpers.ts
+++ b/tests/uat/utils/documentation-helpers.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Documentation Test Helper Utilities
  *

--- a/tests/unit/acronyms.test.ts
+++ b/tests/unit/acronyms.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for acronym utilities
  *

--- a/tests/unit/consolidate.test.ts
+++ b/tests/unit/consolidate.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for Consolidation Module
  *

--- a/tests/unit/discovery.test.ts
+++ b/tests/unit/discovery.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for Discovery Module
  *

--- a/tests/unit/error-handling.test.ts
+++ b/tests/unit/error-handling.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for Error Handling Utilities
  */

--- a/tests/unit/handlers.test.ts
+++ b/tests/unit/handlers.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for Resource Handlers
  */

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for Logging Utilities
  */

--- a/tests/unit/openapi-parser.test.ts
+++ b/tests/unit/openapi-parser.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for OpenAPI Specification Parser
  *

--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for prompts module
  *

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for Tool Registry
  */

--- a/tests/unit/resources.test.ts
+++ b/tests/unit/resources.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit tests for resources module
  */

--- a/tests/unit/rich-metadata.test.ts
+++ b/tests/unit/rich-metadata.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for Rich Metadata Extraction
  *

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for F5XC API MCP Server
  */

--- a/tests/unit/tool-generator.test.ts
+++ b/tests/unit/tool-generator.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for MCP Tool Generator
  */

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * URL Utilities Unit Tests
  *

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Version Consistency Tests
  *

--- a/tests/unit/volterra-mapping.test.ts
+++ b/tests/unit/volterra-mapping.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * Unit Tests for F5XC Tool Naming Utilities
  *

--- a/tests/utils/ci-environment.ts
+++ b/tests/utils/ci-environment.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 /**
  * CI Environment Detection Utility
  *

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,5 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- Add MIT license header to all TypeScript/JavaScript source files and test files
- Update mkdocs.yml copyright notice to reflect MIT license and 2026 year
- Add LICENSE file with MIT license text
- Update year to 2026 in all copyright headers for consistency

## Changes
- **93 files modified**: All source files now include MIT copyright header
- **1 file created**: Added LICENSE file
- **Configuration updated**: mkdocs.yml copyright field

## Test plan
- [x] Pre-commit hooks pass (code formatting, linting, type checking)
- [x] All files have correct header format
- [x] Shebang lines properly positioned (before copyright header)
- [x] No syntax errors introduced

Closes #185

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>