### PR TITLE
test: add schema-driven test generation for healthcheck and origin pool

### DIFF
--- a/tests/uat/chat-queries/healthcheck-creation.test.ts
+++ b/tests/uat/chat-queries/healthcheck-creation.test.ts
@@ -1,0 +1,372 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Healthcheck Creation Tests (v2.0.32+) - Schema-Driven
+ *
+ * Programmatically generates test cases from OpenAPI spec metadata.
+ * Tests are automatically updated when spec changes.
+ *
+ * Test Matrix:
+ * - Plain language query discovery
+ * - Minimal configuration validation
+ * - Recommended values application
+ * - Server default documentation
+ * - Configuration variants
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { searchTools } from "../../../src/tools/discovery/search.js";
+import { describeTool } from "../../../src/tools/discovery/describe.js";
+import { validateToolParams } from "../../../src/tools/discovery/validate.js";
+import {
+  getToolSchemaMetadata,
+  generateTestMatrix,
+  generatePlainLanguageTests,
+  analyzeConfigWithDefaults,
+  getServerDefaultsSummary,
+  getRecommendedValuesSummary,
+} from "../utils/schema-driven-tests.js";
+
+// Mock logger
+vi.mock("../../../src/utils/logging.js", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const HEALTHCHECK_TOOL = "f5xc-api-virtual-healthcheck-create";
+
+// Plain language test mappings
+const PLAIN_LANGUAGE_QUERIES = [
+  {
+    plainText: "Create a health check for my web servers",
+    searchQuery: "create health check",
+    minimalConfig: {
+      metadata: { name: "web-hc", namespace: "default" },
+      spec: { http_health_check: { path: "/health", use_origin_server_name: {} } },
+    },
+  },
+  {
+    plainText: "Set up HTTP health monitoring",
+    searchQuery: "http health check create",
+    minimalConfig: {
+      metadata: { name: "http-hc", namespace: "default" },
+      spec: { http_health_check: { path: "/", use_origin_server_name: {} } },
+    },
+  },
+  {
+    plainText: "Create TCP health check",
+    searchQuery: "create healthcheck tcp",
+    minimalConfig: {
+      metadata: { name: "tcp-hc", namespace: "default" },
+      spec: { tcp_health_check: {} },
+    },
+  },
+  {
+    plainText: "Add health monitoring with 5 second timeout",
+    searchQuery: "create health check timeout",
+    minimalConfig: {
+      metadata: { name: "timeout-hc", namespace: "default" },
+      spec: { timeout: 5, http_health_check: { path: "/health", use_origin_server_name: {} } },
+    },
+  },
+  {
+    plainText: "Create a minimal health check configuration",
+    searchQuery: "create healthcheck minimal",
+    minimalConfig: {
+      metadata: { name: "minimal-hc", namespace: "default" },
+      spec: { http_health_check: { path: "/", use_origin_server_name: {} } },
+    },
+  },
+];
+
+// Base configuration for test matrix
+const BASE_HEALTHCHECK_CONFIG = {
+  metadata: { name: "test-healthcheck", namespace: "default" },
+  spec: { http_health_check: { path: "/health", use_origin_server_name: {} } },
+};
+
+// Optional field variants to test
+const HEALTHCHECK_VARIANTS = {
+  "spec.timeout": [1, 3, 5, 10, 30],
+  "spec.interval": [5, 15, 30, 60],
+  "spec.unhealthy_threshold": [1, 2, 3, 5],
+  "spec.healthy_threshold": [1, 2, 3, 5],
+  "spec.jitter_percent": [0, 10, 30, 50],
+};
+
+// Initialize schema metadata and test matrix synchronously at module load
+// This is required because test registration happens synchronously
+const schemaMetadata = getToolSchemaMetadata(HEALTHCHECK_TOOL);
+
+const testMatrix = generateTestMatrix({
+  toolName: HEALTHCHECK_TOOL,
+  baseConfig: BASE_HEALTHCHECK_CONFIG,
+  requiredFields: ["metadata.name", "metadata.namespace"],
+  optionalFieldVariants: HEALTHCHECK_VARIANTS,
+});
+
+describe("Healthcheck - Schema Metadata Extraction", () => {
+  it("should load healthcheck schema metadata", () => {
+    expect(schemaMetadata).toBeDefined();
+    expect(schemaMetadata.toolName).toBe(HEALTHCHECK_TOOL);
+  });
+
+  it("should extract server defaults from schema", () => {
+    // Server defaults should be extracted from x-f5xc-server-default markers
+    expect(Array.isArray(schemaMetadata.serverDefaults)).toBe(true);
+
+    // Log discovered defaults for visibility
+    console.log("\n📋 Healthcheck Server Defaults:");
+    for (const def of schemaMetadata.serverDefaults) {
+      console.log(`   ${def.fieldPath} → ${JSON.stringify(def.defaultValue)}`);
+    }
+  });
+
+  it("should extract recommended values from schema", () => {
+    expect(Array.isArray(schemaMetadata.recommendedValues)).toBe(true);
+
+    // Log discovered recommended values
+    console.log("\n📋 Healthcheck Recommended Values:");
+    for (const rec of schemaMetadata.recommendedValues) {
+      console.log(`   ${rec.fieldPath} → ${JSON.stringify(rec.recommendedValue)}`);
+    }
+  });
+
+  it("should provide summary for documentation", () => {
+    const serverSummary = getServerDefaultsSummary(HEALTHCHECK_TOOL);
+    const recommendedSummary = getRecommendedValuesSummary(HEALTHCHECK_TOOL);
+
+    expect(Array.isArray(serverSummary)).toBe(true);
+    expect(Array.isArray(recommendedSummary)).toBe(true);
+  });
+});
+
+describe("Healthcheck - Plain Language Query Discovery", () => {
+  const plainLanguageTests = generatePlainLanguageTests(HEALTHCHECK_TOOL, PLAIN_LANGUAGE_QUERIES);
+
+  for (const test of plainLanguageTests) {
+    describe(`Query: "${test.query}"`, () => {
+      it("should find healthcheck tool via search", () => {
+        const results = searchTools(test.searchQuery, { limit: 10 });
+
+        expect(results.length).toBeGreaterThan(0);
+
+        // Should find healthcheck-related tool
+        const hasHealthcheck = results.some(
+          (r) =>
+            r.tool.resource.includes("healthcheck") ||
+            r.tool.name.includes("healthcheck") ||
+            r.tool.resource.includes("health-check")
+        );
+        expect(hasHealthcheck).toBe(true);
+      });
+
+      it("should validate minimal configuration", () => {
+        const result = validateToolParams({
+          toolName: HEALTHCHECK_TOOL,
+          pathParams: { "metadata.namespace": "default" },
+          body: test.config,
+        });
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should analyze what server will apply", () => {
+        const analysis = analyzeConfigWithDefaults(HEALTHCHECK_TOOL, test.config);
+
+        // Server will apply defaults for omitted fields
+        expect(Array.isArray(analysis.serverWillApply)).toBe(true);
+
+        // Log what server will apply
+        if (analysis.serverWillApply.length > 0) {
+          console.log(`\n   Server will apply for "${test.query}":`);
+          for (const applied of analysis.serverWillApply) {
+            console.log(`      ${applied.field} → ${JSON.stringify(applied.value)}`);
+          }
+        }
+      });
+    });
+  }
+});
+
+describe("Healthcheck - Programmatic Configuration Matrix", () => {
+  // This test suite is entirely generated from schema metadata
+  describe("Generated Test Cases", () => {
+    for (const testCase of testMatrix) {
+      it(`should validate: ${testCase.name}`, () => {
+        const result = validateToolParams({
+          toolName: HEALTHCHECK_TOOL,
+          pathParams: { "metadata.namespace": "default" },
+          body: testCase.config,
+        });
+
+        expect(result.valid).toBe(testCase.expectedValid);
+      });
+    }
+  });
+
+  describe("Server Defaults Application", () => {
+    it("should track all server defaults that will be applied to minimal config", () => {
+      const minimalConfig = BASE_HEALTHCHECK_CONFIG;
+      const analysis = analyzeConfigWithDefaults(HEALTHCHECK_TOOL, minimalConfig);
+
+      console.log("\n📊 Server Defaults Analysis for Minimal Config:");
+      console.log(`   Provided fields: ${analysis.providedFields.length}`);
+      console.log(`   Server will apply: ${analysis.serverWillApply.length} defaults`);
+
+      for (const applied of analysis.serverWillApply) {
+        console.log(`      • ${applied.field} → ${JSON.stringify(applied.value)}`);
+      }
+
+      // Verify analysis structure
+      expect(Array.isArray(analysis.serverWillApply)).toBe(true);
+    });
+  });
+});
+
+describe("Healthcheck - Recommended Values Validation", () => {
+  /**
+   * Expected recommended values from v2.0.32 spec:
+   * - timeout: 3 seconds
+   * - interval: 15 seconds
+   * - unhealthy_threshold: 1
+   * - healthy_threshold: 3
+   * - jitter_percent: 30 (for production)
+   */
+
+  const EXPECTED_RECOMMENDATIONS = {
+    "spec.timeout": 3,
+    "spec.interval": 15,
+    "spec.unhealthy_threshold": 1,
+    "spec.healthy_threshold": 3,
+    "spec.jitter_percent": 30,
+  };
+
+  it("should match expected recommended values from spec", () => {
+    const recommendations = schemaMetadata.recommendedValues;
+
+    for (const [field, expectedValue] of Object.entries(EXPECTED_RECOMMENDATIONS)) {
+      // Find matching recommendation (may have different path format)
+      const fieldName = field.split(".").pop();
+      const rec = recommendations.find((r) => r.fieldPath.includes(fieldName!));
+
+      if (rec) {
+        expect(rec.recommendedValue).toBe(expectedValue);
+      }
+    }
+  });
+
+  it("should identify when config uses recommended values", () => {
+    const configWithRecommended = {
+      metadata: { name: "recommended-hc", namespace: "default" },
+      spec: {
+        timeout: 3,
+        interval: 15,
+        unhealthy_threshold: 1,
+        healthy_threshold: 3,
+        jitter_percent: 30,
+        http_health_check: { path: "/health", use_origin_server_name: {} },
+      },
+    };
+
+    const analysis = analyzeConfigWithDefaults(HEALTHCHECK_TOOL, configWithRecommended);
+
+    console.log("\n✅ Fields matching recommended values:");
+    for (const match of analysis.matchesRecommended) {
+      console.log(`   ${match.field}: ${match.provided} (recommended: ${match.recommended})`);
+    }
+
+    // When using recommended values, server doesn't need to apply defaults for those
+    expect(analysis.matchesRecommended.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it("should identify when config uses values below recommended", () => {
+    const configBelowRecommended = {
+      metadata: { name: "below-rec-hc", namespace: "default" },
+      spec: {
+        timeout: 1, // Below recommended 3
+        interval: 5, // Below recommended 15
+        unhealthy_threshold: 1,
+        healthy_threshold: 1, // Below recommended 3
+        http_health_check: { path: "/health", use_origin_server_name: {} },
+      },
+    };
+
+    const analysis = analyzeConfigWithDefaults(HEALTHCHECK_TOOL, configBelowRecommended);
+
+    console.log("\n⚠️ Fields below recommended values:");
+    for (const below of analysis.belowRecommended) {
+      console.log(`   ${below.field}: ${below.provided} < ${below.recommended} (recommended)`);
+    }
+
+    // Advisory: these values work but are below recommended
+    expect(Array.isArray(analysis.belowRecommended)).toBe(true);
+  });
+});
+
+describe("Healthcheck - Search Tool Integration", () => {
+  it("should find create tool with POST method", async () => {
+    const results = searchTools("create healthcheck", { operations: ["create"], limit: 1 });
+
+    expect(results.length).toBeGreaterThan(0);
+
+    const description = await describeTool(results[0].tool.name);
+    expect(description.method).toBe("POST");
+  });
+
+  it("should filter to virtual domain", () => {
+    const results = searchTools("healthcheck", { domains: ["virtual"], limit: 5 });
+
+    expect(results.every((r) => r.tool.domain === "virtual")).toBe(true);
+  });
+
+  it("should filter to create operations only", () => {
+    const results = searchTools("healthcheck", { operations: ["create"], limit: 5 });
+
+    expect(results.every((r) => r.tool.operation === "create")).toBe(true);
+  });
+});
+
+describe("Healthcheck - Error Handling", () => {
+  it("should warn when metadata.name is missing", () => {
+    const invalidConfig = {
+      metadata: { namespace: "default" },
+      spec: { http_health_check: { path: "/health", use_origin_server_name: {} } },
+    };
+
+    const result = validateToolParams({
+      toolName: HEALTHCHECK_TOOL,
+      pathParams: { "metadata.namespace": "default" },
+      body: invalidConfig,
+    });
+
+    expect(result.warnings.some((w) => w.toLowerCase().includes("name"))).toBe(true);
+  });
+
+  it("should pass validation when body is missing for documentation mode", () => {
+    const result = validateToolParams({
+      toolName: HEALTHCHECK_TOOL,
+      pathParams: { "metadata.namespace": "default" },
+    });
+
+    // Errors are expected for missing body in create operation
+    // But tool should be found
+    expect(result.tool).toBeDefined();
+  });
+});
+
+describe("Healthcheck - Test Matrix Statistics", () => {
+  it("should report generated test statistics", () => {
+    console.log("\n📊 Healthcheck Test Matrix Statistics:");
+    console.log(`   Total generated test cases: ${testMatrix.length}`);
+    console.log(`   Server defaults tracked: ${schemaMetadata.serverDefaults.length}`);
+    console.log(`   Recommended values tracked: ${schemaMetadata.recommendedValues.length}`);
+    console.log(`   Plain language queries tested: ${PLAIN_LANGUAGE_QUERIES.length}`);
+
+    expect(testMatrix.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/uat/chat-queries/origin-pool-creation.test.ts
+++ b/tests/uat/chat-queries/origin-pool-creation.test.ts
@@ -1,0 +1,590 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Origin Pool Creation Tests (v2.0.33+) - Schema-Driven
+ *
+ * Programmatically generates test cases from OpenAPI spec metadata.
+ * Tests are automatically updated when spec changes.
+ *
+ * Key v2.0.33 Enhancements:
+ * - UI vs Server algorithm discrepancy documented
+ * - Server defaults: ROUND_ROBIN, DISTRIBUTED, no_tls
+ * - OneOf field patterns for mutual exclusivity
+ *
+ * Test Matrix:
+ * - Plain language query discovery
+ * - Minimal configuration validation
+ * - Server default application
+ * - OneOf pattern validation
+ * - Configuration variants
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { searchTools } from "../../../src/tools/discovery/search.js";
+import { describeTool } from "../../../src/tools/discovery/describe.js";
+import { validateToolParams } from "../../../src/tools/discovery/validate.js";
+import {
+  getToolSchemaMetadata,
+  generateTestMatrix,
+  generatePlainLanguageTests,
+  generateOneOfTests,
+  analyzeConfigWithDefaults,
+  getServerDefaultsSummary,
+  getRecommendedValuesSummary,
+} from "../utils/schema-driven-tests.js";
+
+// Mock logger
+vi.mock("../../../src/utils/logging.js", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const ORIGIN_POOL_TOOL = "f5xc-api-virtual-origin-pool-create";
+
+// Plain language test mappings
+const PLAIN_LANGUAGE_QUERIES = [
+  {
+    plainText: "Create an origin pool for my backend servers",
+    searchQuery: "create origin pool",
+    minimalConfig: {
+      metadata: { name: "backend-pool", namespace: "default" },
+      spec: {
+        origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+        port: 80,
+      },
+    },
+  },
+  {
+    plainText: "Set up a backend pool with multiple servers",
+    searchQuery: "backend pool servers",
+    minimalConfig: {
+      metadata: { name: "multi-pool", namespace: "default" },
+      spec: {
+        origin_servers: [
+          { public_ip: { ip: "192.0.2.1" } },
+          { public_ip: { ip: "192.0.2.2" } },
+        ],
+        port: 8080,
+      },
+    },
+  },
+  {
+    plainText: "Create origin pool with TLS to backend",
+    searchQuery: "create origin pool tls",
+    minimalConfig: {
+      metadata: { name: "tls-pool", namespace: "default" },
+      spec: {
+        origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+        port: 443,
+        use_tls: { use_host_header_as_sni: {} },
+      },
+    },
+  },
+  {
+    plainText: "Configure load balancing for my origins",
+    searchQuery: "create origin pool",
+    minimalConfig: {
+      metadata: { name: "lb-pool", namespace: "default" },
+      spec: {
+        origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+        port: 80,
+        loadbalancer_algorithm: "LEAST_REQUEST",
+      },
+    },
+  },
+  {
+    plainText: "Create HTTPS origin pool",
+    searchQuery: "create origin pool https",
+    minimalConfig: {
+      metadata: { name: "https-pool", namespace: "default" },
+      spec: {
+        origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+        port: 443,
+        use_tls: { use_host_header_as_sni: {} },
+      },
+    },
+  },
+];
+
+// Base configuration for test matrix
+const BASE_ORIGIN_POOL_CONFIG = {
+  metadata: { name: "test-origin-pool", namespace: "default" },
+  spec: {
+    origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+    port: 80,
+  },
+};
+
+// Optional field variants to test
+const ORIGIN_POOL_VARIANTS = {
+  "spec.port": [80, 443, 8080, 8443],
+  "spec.loadbalancer_algorithm": [
+    "ROUND_ROBIN",
+    "LEAST_REQUEST",
+    "RING_HASH",
+    "RANDOM",
+    "LB_OVERRIDE",
+  ],
+  "spec.endpoint_selection": ["DISTRIBUTED", "LOCAL_PREFERRED", "LOCAL_ONLY"],
+};
+
+// OneOf field groups for origin pool
+const ORIGIN_POOL_ONEOF_GROUPS = [
+  {
+    name: "TLS Configuration",
+    options: ["no_tls", "use_tls"],
+    validConfigs: [
+      {
+        metadata: { name: "notls-pool", namespace: "default" },
+        spec: {
+          origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+          port: 80,
+          no_tls: {},
+        },
+      },
+      {
+        metadata: { name: "tls-pool", namespace: "default" },
+        spec: {
+          origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+          port: 443,
+          use_tls: { use_host_header_as_sni: {} },
+        },
+      },
+    ],
+  },
+  {
+    name: "Port Selection",
+    options: ["port", "automatic_port", "lb_port"],
+    validConfigs: [
+      {
+        metadata: { name: "explicit-port", namespace: "default" },
+        spec: {
+          origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+          port: 8080,
+        },
+      },
+      {
+        metadata: { name: "auto-port", namespace: "default" },
+        spec: {
+          origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+          automatic_port: {},
+        },
+      },
+    ],
+  },
+];
+
+// Expected server defaults from v2.0.33 spec
+const EXPECTED_SERVER_DEFAULTS = {
+  loadbalancer_algorithm: "ROUND_ROBIN",
+  endpoint_selection: "DISTRIBUTED",
+  no_tls: {}, // Empty object means TLS disabled
+  connection_timeout_ms: 2000,
+  http_idle_timeout_ms: 300000,
+};
+
+// Known UI vs Server discrepancy
+const UI_SERVER_DISCREPANCY = {
+  field: "loadbalancer_algorithm",
+  uiDefault: "LB_OVERRIDE",
+  serverDefault: "ROUND_ROBIN",
+  impact: "API-created pools use ROUND_ROBIN, UI-created use LB_OVERRIDE",
+};
+
+// Initialize schema metadata and test matrix synchronously at module load
+// This is required because test registration happens synchronously
+const schemaMetadata = getToolSchemaMetadata(ORIGIN_POOL_TOOL);
+
+const testMatrix = generateTestMatrix({
+  toolName: ORIGIN_POOL_TOOL,
+  baseConfig: BASE_ORIGIN_POOL_CONFIG,
+  requiredFields: ["metadata.name", "metadata.namespace", "spec.origin_servers", "spec.port"],
+  optionalFieldVariants: ORIGIN_POOL_VARIANTS,
+});
+
+const oneOfTests = generateOneOfTests(ORIGIN_POOL_TOOL, ORIGIN_POOL_ONEOF_GROUPS);
+
+describe("Origin Pool - Schema Metadata Extraction", () => {
+  it("should load origin pool schema metadata", () => {
+    expect(schemaMetadata).toBeDefined();
+    expect(schemaMetadata.toolName).toBe(ORIGIN_POOL_TOOL);
+  });
+
+  it("should extract server defaults from schema", () => {
+    expect(Array.isArray(schemaMetadata.serverDefaults)).toBe(true);
+
+    console.log("\n📋 Origin Pool Server Defaults:");
+    for (const def of schemaMetadata.serverDefaults) {
+      console.log(`   ${def.fieldPath} → ${JSON.stringify(def.defaultValue)}`);
+    }
+  });
+
+  it("should extract recommended values from schema", () => {
+    expect(Array.isArray(schemaMetadata.recommendedValues)).toBe(true);
+
+    console.log("\n📋 Origin Pool Recommended Values:");
+    for (const rec of schemaMetadata.recommendedValues) {
+      console.log(`   ${rec.fieldPath} → ${JSON.stringify(rec.recommendedValue)}`);
+    }
+  });
+
+  it("should provide summary for documentation", () => {
+    const serverSummary = getServerDefaultsSummary(ORIGIN_POOL_TOOL);
+    const recommendedSummary = getRecommendedValuesSummary(ORIGIN_POOL_TOOL);
+
+    expect(Array.isArray(serverSummary)).toBe(true);
+    expect(Array.isArray(recommendedSummary)).toBe(true);
+  });
+});
+
+describe("Origin Pool - Critical UI vs Server Discrepancy", () => {
+  /**
+   * CRITICAL DOCUMENTATION (v2.0.33):
+   *
+   * The F5 XC web UI pre-selects LB_OVERRIDE for loadbalancer_algorithm,
+   * but the server applies ROUND_ROBIN when the field is omitted.
+   *
+   * This causes different behavior between:
+   * - UI-created configurations (LB_OVERRIDE)
+   * - API-created configurations (ROUND_ROBIN default)
+   *
+   * AI assistants generating minimal configs should be aware of this.
+   */
+
+  it("should document the discrepancy between UI and server defaults", () => {
+    expect(UI_SERVER_DISCREPANCY.uiDefault).not.toBe(UI_SERVER_DISCREPANCY.serverDefault);
+    expect(UI_SERVER_DISCREPANCY.serverDefault).toBe("ROUND_ROBIN");
+    expect(UI_SERVER_DISCREPANCY.uiDefault).toBe("LB_OVERRIDE");
+
+    console.log("\n⚠️ CRITICAL: UI vs Server Algorithm Discrepancy");
+    console.log(`   Field: ${UI_SERVER_DISCREPANCY.field}`);
+    console.log(`   UI Default: ${UI_SERVER_DISCREPANCY.uiDefault}`);
+    console.log(`   Server Default: ${UI_SERVER_DISCREPANCY.serverDefault}`);
+    console.log(`   Impact: ${UI_SERVER_DISCREPANCY.impact}`);
+  });
+
+  it("should verify server default for loadbalancer_algorithm", () => {
+    const algorithmDefault = schemaMetadata.serverDefaults.find((d) =>
+      d.fieldPath.includes("loadbalancer_algorithm")
+    );
+
+    if (algorithmDefault) {
+      expect(algorithmDefault.isServerDefault).toBe(true);
+      expect(algorithmDefault.defaultValue).toBe("ROUND_ROBIN");
+    }
+  });
+
+  it("should verify server default for endpoint_selection", () => {
+    const endpointDefault = schemaMetadata.serverDefaults.find((d) =>
+      d.fieldPath.includes("endpoint_selection")
+    );
+
+    if (endpointDefault) {
+      expect(endpointDefault.isServerDefault).toBe(true);
+      expect(endpointDefault.defaultValue).toBe("DISTRIBUTED");
+    }
+  });
+
+  it("should verify server default for TLS (no_tls)", () => {
+    const tlsDefault = schemaMetadata.serverDefaults.find((d) => d.fieldPath.includes("no_tls"));
+
+    if (tlsDefault) {
+      expect(tlsDefault.isServerDefault).toBe(true);
+      expect(tlsDefault.defaultValue).toEqual({});
+    }
+  });
+});
+
+describe("Origin Pool - Plain Language Query Discovery", () => {
+  const plainLanguageTests = generatePlainLanguageTests(ORIGIN_POOL_TOOL, PLAIN_LANGUAGE_QUERIES);
+
+  for (const test of plainLanguageTests) {
+    describe(`Query: "${test.query}"`, () => {
+      it("should find origin pool tool via search", () => {
+        const results = searchTools(test.searchQuery, { limit: 10 });
+
+        expect(results.length).toBeGreaterThan(0);
+
+        // Should find origin-pool related tool
+        const hasOriginPool = results.some(
+          (r) =>
+            r.tool.resource.includes("origin-pool") || r.tool.name.includes("origin-pool")
+        );
+        expect(hasOriginPool).toBe(true);
+      });
+
+      it("should validate minimal configuration", () => {
+        const result = validateToolParams({
+          toolName: ORIGIN_POOL_TOOL,
+          pathParams: { "metadata.namespace": "default" },
+          body: test.config,
+        });
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should analyze what server will apply", () => {
+        const analysis = analyzeConfigWithDefaults(ORIGIN_POOL_TOOL, test.config);
+
+        expect(Array.isArray(analysis.serverWillApply)).toBe(true);
+
+        if (analysis.serverWillApply.length > 0) {
+          console.log(`\n   Server will apply for "${test.query}":`);
+          for (const applied of analysis.serverWillApply) {
+            console.log(`      ${applied.field} → ${JSON.stringify(applied.value)}`);
+          }
+        }
+      });
+    });
+  }
+});
+
+describe("Origin Pool - Programmatic Configuration Matrix", () => {
+  describe("Generated Test Cases", () => {
+    for (const testCase of testMatrix) {
+      it(`should validate: ${testCase.name}`, () => {
+        const result = validateToolParams({
+          toolName: ORIGIN_POOL_TOOL,
+          pathParams: { "metadata.namespace": "default" },
+          body: testCase.config,
+        });
+
+        expect(result.valid).toBe(testCase.expectedValid);
+      });
+    }
+  });
+
+  describe("Server Defaults Application", () => {
+    it("should track all server defaults for minimal config", () => {
+      const minimalConfig = BASE_ORIGIN_POOL_CONFIG;
+      const analysis = analyzeConfigWithDefaults(ORIGIN_POOL_TOOL, minimalConfig);
+
+      console.log("\n📊 Server Defaults Analysis for Minimal Origin Pool:");
+      console.log(`   Provided fields: ${analysis.providedFields.length}`);
+      console.log(`   Server will apply: ${analysis.serverWillApply.length} defaults`);
+
+      for (const applied of analysis.serverWillApply) {
+        console.log(`      • ${applied.field} → ${JSON.stringify(applied.value)}`);
+      }
+
+      expect(Array.isArray(analysis.serverWillApply)).toBe(true);
+    });
+  });
+});
+
+describe("Origin Pool - OneOf Field Patterns", () => {
+  /**
+   * Origin pool OneOf groups (v2.0.33):
+   * - Port: port | automatic_port | lb_port
+   * - TLS: no_tls | use_tls
+   * - Circuit Breaker: default_circuit_breaker | disable_circuit_breaker | circuit_breaker
+   * - HTTP Protocol: auto_http_config | http1_config | http2_options
+   * - Health Check Port: same_as_endpoint_port | health_check_port
+   */
+
+  describe("Generated OneOf Tests", () => {
+    for (const testCase of oneOfTests) {
+      it(`should validate: ${testCase.name}`, () => {
+        const result = validateToolParams({
+          toolName: ORIGIN_POOL_TOOL,
+          pathParams: { "metadata.namespace": "default" },
+          body: testCase.config,
+        });
+
+        // OneOf tests may pass or produce warnings
+        expect(typeof result.valid).toBe("boolean");
+      });
+    }
+  });
+
+  describe("TLS OneOf Validation", () => {
+    it("should accept no_tls without use_tls", () => {
+      const config = {
+        metadata: { name: "notls-pool", namespace: "default" },
+        spec: {
+          origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+          port: 80,
+          no_tls: {},
+        },
+      };
+
+      const result = validateToolParams({
+        toolName: ORIGIN_POOL_TOOL,
+        pathParams: { "metadata.namespace": "default" },
+        body: config,
+      });
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should accept use_tls without no_tls", () => {
+      const config = {
+        metadata: { name: "tls-pool", namespace: "default" },
+        spec: {
+          origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+          port: 443,
+          use_tls: { use_host_header_as_sni: {} },
+        },
+      };
+
+      const result = validateToolParams({
+        toolName: ORIGIN_POOL_TOOL,
+        pathParams: { "metadata.namespace": "default" },
+        body: config,
+      });
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("Load Balancer Algorithm Options", () => {
+    const algorithms = ["ROUND_ROBIN", "LEAST_REQUEST", "RING_HASH", "RANDOM", "LB_OVERRIDE"];
+
+    for (const algo of algorithms) {
+      it(`should accept loadbalancer_algorithm: ${algo}`, () => {
+        const config = {
+          metadata: { name: `${algo.toLowerCase()}-pool`, namespace: "default" },
+          spec: {
+            origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+            port: 80,
+            loadbalancer_algorithm: algo,
+          },
+        };
+
+        const result = validateToolParams({
+          toolName: ORIGIN_POOL_TOOL,
+          pathParams: { "metadata.namespace": "default" },
+          body: config,
+        });
+
+        expect(result.valid).toBe(true);
+      });
+    }
+  });
+});
+
+describe("Origin Pool - Required Fields Validation", () => {
+  it("should validate complete minimal configuration", () => {
+    const config = {
+      metadata: { name: "minimal-pool", namespace: "default" },
+      spec: {
+        origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+        port: 80,
+      },
+    };
+
+    const result = validateToolParams({
+      toolName: ORIGIN_POOL_TOOL,
+      pathParams: { "metadata.namespace": "default" },
+      body: config,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it("should warn when metadata.name is missing", () => {
+    const config = {
+      metadata: { namespace: "default" },
+      spec: {
+        origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+        port: 80,
+      },
+    };
+
+    const result = validateToolParams({
+      toolName: ORIGIN_POOL_TOOL,
+      pathParams: { "metadata.namespace": "default" },
+      body: config,
+    });
+
+    expect(result.warnings.some((w) => w.toLowerCase().includes("name"))).toBe(true);
+  });
+});
+
+describe("Origin Pool - Search Tool Integration", () => {
+  it("should find create tool with POST method", async () => {
+    const results = searchTools("create origin pool", { operations: ["create"], limit: 1 });
+
+    expect(results.length).toBeGreaterThan(0);
+
+    const description = await describeTool(results[0].tool.name);
+    expect(description.method).toBe("POST");
+  });
+
+  it("should filter to virtual domain", () => {
+    const results = searchTools("origin pool", { domains: ["virtual"], limit: 5 });
+
+    expect(results.every((r) => r.tool.domain === "virtual")).toBe(true);
+  });
+
+  it("should filter to create operations only", () => {
+    const results = searchTools("origin pool", { operations: ["create"], limit: 5 });
+
+    expect(results.every((r) => r.tool.operation === "create")).toBe(true);
+  });
+});
+
+describe("Origin Pool - Server Defaults Documentation", () => {
+  /**
+   * Documented server defaults from v2.0.33:
+   */
+  const DOCUMENTED_DEFAULTS = {
+    loadbalancer_algorithm: "ROUND_ROBIN",
+    endpoint_selection: "DISTRIBUTED",
+    tls_to_origin: "no_tls (disabled)",
+    connection_timeout: "2000ms",
+    http_idle_timeout: "300000ms (5 minutes)",
+    circuit_breaker: "default_circuit_breaker (enabled)",
+    outlier_detection: "disabled",
+    http_protocol: "auto_http_config (auto-negotiation)",
+    proxy_protocol: "disabled",
+  };
+
+  it("should document all known server defaults", () => {
+    console.log("\n📋 Origin Pool Server Defaults (v2.0.33):");
+    for (const [field, value] of Object.entries(DOCUMENTED_DEFAULTS)) {
+      console.log(`   ${field}: ${value}`);
+    }
+
+    expect(DOCUMENTED_DEFAULTS.loadbalancer_algorithm).toBe("ROUND_ROBIN");
+    expect(DOCUMENTED_DEFAULTS.endpoint_selection).toBe("DISTRIBUTED");
+  });
+
+  it("should verify minimal config uses server defaults", () => {
+    const minimalConfig = {
+      metadata: { name: "test-pool", namespace: "default" },
+      spec: {
+        origin_servers: [{ public_ip: { ip: "192.0.2.1" } }],
+        port: 80,
+      },
+    };
+
+    const analysis = analyzeConfigWithDefaults(ORIGIN_POOL_TOOL, minimalConfig);
+
+    // Verify the configuration doesn't specify these fields
+    expect(
+      analysis.providedFields.some((f) => f.includes("loadbalancer_algorithm"))
+    ).toBe(false);
+    expect(analysis.providedFields.some((f) => f.includes("endpoint_selection"))).toBe(
+      false
+    );
+  });
+});
+
+describe("Origin Pool - Test Matrix Statistics", () => {
+  it("should report generated test statistics", () => {
+    console.log("\n📊 Origin Pool Test Matrix Statistics:");
+    console.log(`   Total generated test cases: ${testMatrix.length}`);
+    console.log(`   OneOf test cases: ${oneOfTests.length}`);
+    console.log(`   Server defaults tracked: ${schemaMetadata.serverDefaults.length}`);
+    console.log(`   Recommended values tracked: ${schemaMetadata.recommendedValues.length}`);
+    console.log(`   Plain language queries tested: ${PLAIN_LANGUAGE_QUERIES.length}`);
+    console.log(`   LB algorithm variants: ${ORIGIN_POOL_VARIANTS["spec.loadbalancer_algorithm"].length}`);
+
+    expect(testMatrix.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/uat/utils/schema-driven-tests.ts
+++ b/tests/uat/utils/schema-driven-tests.ts
@@ -1,0 +1,377 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Schema-Driven Test Generation Utilities
+ *
+ * Programmatically generates test configurations and expectations
+ * based on the OpenAPI spec metadata. This ensures tests stay in sync
+ * with spec changes and recommended values.
+ */
+
+import {
+  getResolvedRequestBodySchema,
+  extractFieldDefaults,
+  type ResolvedSchema,
+} from "../../../src/tools/discovery/schema-loader.js";
+import type { FieldDefaultMetadata } from "../../../src/generator/openapi-parser.js";
+
+/**
+ * Generated test case for a tool
+ */
+export interface GeneratedTestCase {
+  name: string;
+  description: string;
+  config: Record<string, unknown>;
+  expectedValid: boolean;
+  serverAppliedDefaults: Array<{
+    field: string;
+    value: unknown;
+  }>;
+  recommendedValues: Array<{
+    field: string;
+    value: unknown;
+  }>;
+}
+
+/**
+ * Test matrix configuration
+ */
+export interface TestMatrixConfig {
+  toolName: string;
+  baseConfig: Record<string, unknown>;
+  requiredFields: string[];
+  optionalFieldVariants: Record<string, unknown[]>;
+}
+
+/**
+ * Schema metadata for a tool
+ */
+export interface ToolSchemaMetadata {
+  toolName: string;
+  serverDefaults: FieldDefaultMetadata[];
+  recommendedValues: FieldDefaultMetadata[];
+  allDefaults: FieldDefaultMetadata[];
+  schema: ResolvedSchema | null;
+}
+
+/**
+ * Extract schema metadata for a tool
+ * @param toolName - Full tool name (e.g., "f5xc-api-virtual-healthcheck-create")
+ * @returns Schema metadata including defaults and recommended values
+ */
+export function getToolSchemaMetadata(toolName: string): ToolSchemaMetadata {
+  const schema = getResolvedRequestBodySchema(toolName);
+  const allDefaults = schema ? extractFieldDefaults(schema) : [];
+
+  return {
+    toolName,
+    serverDefaults: allDefaults.filter((d) => d.isServerDefault),
+    recommendedValues: allDefaults.filter((d) => d.recommendedValue !== undefined),
+    allDefaults,
+    schema,
+  };
+}
+
+/**
+ * Generate a minimal valid configuration using recommended values
+ * @param toolName - Tool name
+ * @param baseRequired - Base required fields configuration
+ * @returns Configuration with recommended values applied
+ */
+export function generateRecommendedConfig(
+  toolName: string,
+  baseRequired: Record<string, unknown>
+): Record<string, unknown> {
+  const metadata = getToolSchemaMetadata(toolName);
+  const config = JSON.parse(JSON.stringify(baseRequired)) as Record<string, unknown>;
+
+  // Apply recommended values
+  for (const rec of metadata.recommendedValues) {
+    setNestedValue(config, rec.fieldPath, rec.recommendedValue);
+  }
+
+  return config;
+}
+
+/**
+ * Generate test cases for a tool based on its schema
+ * @param config - Test matrix configuration
+ * @returns Array of generated test cases
+ */
+export function generateTestMatrix(config: TestMatrixConfig): GeneratedTestCase[] {
+  const metadata = getToolSchemaMetadata(config.toolName);
+  const testCases: GeneratedTestCase[] = [];
+
+  // Test case 1: Minimal config (only required fields)
+  testCases.push({
+    name: "Minimal configuration (required fields only)",
+    description: "Tests that server applies defaults for all omitted optional fields",
+    config: JSON.parse(JSON.stringify(config.baseConfig)),
+    expectedValid: true,
+    serverAppliedDefaults: metadata.serverDefaults.map((d) => ({
+      field: d.fieldPath,
+      value: d.defaultValue,
+    })),
+    recommendedValues: metadata.recommendedValues.map((d) => ({
+      field: d.fieldPath,
+      value: d.recommendedValue,
+    })),
+  });
+
+  // Test case 2: All recommended values
+  const recommendedConfig = generateRecommendedConfig(config.toolName, config.baseConfig);
+  testCases.push({
+    name: "All recommended values",
+    description: "Tests configuration with all UI-recommended values explicitly set",
+    config: recommendedConfig,
+    expectedValid: true,
+    serverAppliedDefaults: [], // No defaults needed when values are explicit
+    recommendedValues: metadata.recommendedValues.map((d) => ({
+      field: d.fieldPath,
+      value: d.recommendedValue,
+    })),
+  });
+
+  // Test case 3: Generate variant test cases for optional fields
+  for (const [fieldName, values] of Object.entries(config.optionalFieldVariants)) {
+    for (const value of values) {
+      const variantConfig = JSON.parse(JSON.stringify(config.baseConfig)) as Record<
+        string,
+        unknown
+      >;
+      setNestedValue(variantConfig, fieldName, value);
+
+      testCases.push({
+        name: `With ${fieldName} = ${JSON.stringify(value)}`,
+        description: `Tests explicit ${fieldName} value overriding server default`,
+        config: variantConfig,
+        expectedValid: true,
+        serverAppliedDefaults: metadata.serverDefaults
+          .filter((d) => d.fieldPath !== fieldName)
+          .map((d) => ({ field: d.fieldPath, value: d.defaultValue })),
+        recommendedValues: [],
+      });
+    }
+  }
+
+  return testCases;
+}
+
+/**
+ * Generate test cases for OneOf field patterns
+ * @param toolName - Tool name
+ * @param oneOfGroups - Array of OneOf group configurations
+ * @returns Test cases for mutual exclusivity validation
+ */
+export function generateOneOfTests(
+  toolName: string,
+  oneOfGroups: Array<{
+    name: string;
+    options: string[];
+    validConfigs: Record<string, unknown>[];
+    invalidConfig?: Record<string, unknown>;
+  }>
+): GeneratedTestCase[] {
+  const testCases: GeneratedTestCase[] = [];
+
+  for (const group of oneOfGroups) {
+    // Valid: Each option alone
+    for (let i = 0; i < group.validConfigs.length; i++) {
+      testCases.push({
+        name: `${group.name}: ${group.options[i]} only`,
+        description: `Tests that ${group.options[i]} is valid when specified alone`,
+        config: group.validConfigs[i],
+        expectedValid: true,
+        serverAppliedDefaults: [],
+        recommendedValues: [],
+      });
+    }
+
+    // Invalid: Multiple options (if provided)
+    if (group.invalidConfig) {
+      testCases.push({
+        name: `${group.name}: Multiple options (invalid)`,
+        description: `Tests that specifying multiple mutually exclusive options produces warning`,
+        config: group.invalidConfig,
+        expectedValid: false, // Should warn about mutual exclusivity
+        serverAppliedDefaults: [],
+        recommendedValues: [],
+      });
+    }
+  }
+
+  return testCases;
+}
+
+/**
+ * Generate plain language query test mappings
+ * @param toolName - Tool name
+ * @param queries - Natural language queries to test
+ * @returns Test configuration for plain language tests
+ */
+export function generatePlainLanguageTests(
+  toolName: string,
+  queries: Array<{
+    plainText: string;
+    searchQuery: string;
+    minimalConfig: Record<string, unknown>;
+  }>
+): Array<{
+  query: string;
+  searchQuery: string;
+  config: Record<string, unknown>;
+  metadata: ToolSchemaMetadata;
+}> {
+  const metadata = getToolSchemaMetadata(toolName);
+
+  return queries.map((q) => ({
+    query: q.plainText,
+    searchQuery: q.searchQuery,
+    config: q.minimalConfig,
+    metadata,
+  }));
+}
+
+/**
+ * Set a nested value in an object using dot notation
+ */
+function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split(".");
+  let current = obj;
+
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (!(part in current) || typeof current[part] !== "object") {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+
+  current[parts[parts.length - 1]] = value;
+}
+
+/**
+ * Get expected server defaults summary for documentation
+ */
+export function getServerDefaultsSummary(
+  toolName: string
+): Array<{ field: string; serverDefault: unknown; description: string }> {
+  const metadata = getToolSchemaMetadata(toolName);
+
+  return metadata.serverDefaults.map((d) => ({
+    field: d.fieldPath,
+    serverDefault: d.defaultValue,
+    description: d.requiredForCreate
+      ? "User-required but has server default"
+      : "Server applies default if omitted",
+  }));
+}
+
+/**
+ * Get recommended values summary for documentation
+ */
+export function getRecommendedValuesSummary(
+  toolName: string
+): Array<{ field: string; recommended: unknown; serverDefault?: unknown }> {
+  const metadata = getToolSchemaMetadata(toolName);
+
+  return metadata.recommendedValues.map((d) => {
+    const serverDefault = metadata.serverDefaults.find((s) => s.fieldPath === d.fieldPath);
+    return {
+      field: d.fieldPath,
+      recommended: d.recommendedValue,
+      serverDefault: serverDefault?.defaultValue,
+    };
+  });
+}
+
+/**
+ * Validate that a configuration will work with server defaults
+ * Returns what the server will apply
+ */
+export function analyzeConfigWithDefaults(
+  toolName: string,
+  config: Record<string, unknown>
+): {
+  providedFields: string[];
+  serverWillApply: Array<{ field: string; value: unknown }>;
+  matchesRecommended: Array<{ field: string; provided: unknown; recommended: unknown }>;
+  belowRecommended: Array<{ field: string; provided: unknown; recommended: unknown }>;
+} {
+  const metadata = getToolSchemaMetadata(toolName);
+  const providedFields: string[] = [];
+  const serverWillApply: Array<{ field: string; value: unknown }> = [];
+  const matchesRecommended: Array<{
+    field: string;
+    provided: unknown;
+    recommended: unknown;
+  }> = [];
+  const belowRecommended: Array<{
+    field: string;
+    provided: unknown;
+    recommended: unknown;
+  }> = [];
+
+  // Check what's provided
+  for (const def of metadata.allDefaults) {
+    const providedValue = getNestedValue(config, def.fieldPath);
+
+    if (providedValue !== undefined) {
+      providedFields.push(def.fieldPath);
+
+      // Check against recommended
+      if (def.recommendedValue !== undefined) {
+        if (providedValue === def.recommendedValue) {
+          matchesRecommended.push({
+            field: def.fieldPath,
+            provided: providedValue,
+            recommended: def.recommendedValue,
+          });
+        } else if (
+          typeof providedValue === "number" &&
+          typeof def.recommendedValue === "number" &&
+          providedValue < def.recommendedValue
+        ) {
+          belowRecommended.push({
+            field: def.fieldPath,
+            provided: providedValue,
+            recommended: def.recommendedValue,
+          });
+        }
+      }
+    } else if (def.isServerDefault) {
+      // Server will apply default
+      serverWillApply.push({
+        field: def.fieldPath,
+        value: def.defaultValue,
+      });
+    }
+  }
+
+  return {
+    providedFields,
+    serverWillApply,
+    matchesRecommended,
+    belowRecommended,
+  };
+}
+
+/**
+ * Get nested value from object using dot notation
+ */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split(".");
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+    if (typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current;
+}


### PR DESCRIPTION
## Summary

Add comprehensive schema-driven test generation framework that programmatically generates test cases from OpenAPI spec metadata.

## Changes

- **schema-driven-tests.ts**: Core test generation utilities
  - `generateTestMatrix()`: Create variant test cases from optional field combinations
  - `generateOneOfTests()`: Validate mutual exclusivity patterns
  - `generatePlainLanguageTests()`: Map natural language queries
  - `analyzeConfigWithDefaults()`: Track server defaults and recommendations

- **healthcheck-creation.test.ts**: Healthcheck-specific tests
  - Extracts server defaults and recommended values
  - Plain language query discovery
  - Configuration variants (timeout, interval, thresholds)
  - v2.0.32 spec validation

- **origin-pool-creation.test.ts**: Origin pool-specific tests
  - Documents UI vs server algorithm discrepancy
  - OneOf validation (TLS, port, circuit breaker)
  - Server defaults validation (ROUND_ROBIN, DISTRIBUTED, no_tls)
  - v2.0.33 spec validation

## Benefits

- Tests automatically sync with spec changes
- Comprehensive configuration variant coverage
- Tracks server-applied defaults and recommended values
- Validates OneOf mutual exclusivity patterns
- Ensures consistent behavior across API updates

Closes #230