### PR TITLE
fix: preserve sibling properties when resolving $ref in schema

### DIFF
--- a/src/tools/discovery/schema-loader.ts
+++ b/src/tools/discovery/schema-loader.ts
@@ -228,7 +228,8 @@ export function resolveNestedRefs(
 
   const obj = schema as Record<string, unknown>;
 
-  // Handle $ref
+  // Handle $ref with sibling property preservation (v2.0.33+)
+  // JSON Schema allows sibling keywords alongside $ref - we must merge them
   if ("$ref" in obj && typeof obj["$ref"] === "string") {
     const ref = obj["$ref"];
 
@@ -241,8 +242,24 @@ export function resolveNestedRefs(
 
     const resolved = resolveSchemaRef(ref, domain);
     if (resolved) {
+      // Extract sibling properties (everything except $ref)
+      const siblingProps: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(obj)) {
+        if (key !== "$ref") {
+          siblingProps[key] = value;
+        }
+      }
+
       // Continue resolving nested refs in the resolved schema
-      return resolveNestedRefs(resolved, domain, depth + 1, new Set(visited));
+      const resolvedSchema = resolveNestedRefs(resolved, domain, depth + 1, new Set(visited));
+
+      // Merge sibling properties with resolved schema
+      // Sibling properties (like default, x-f5xc-server-default) take precedence
+      if (Object.keys(siblingProps).length > 0) {
+        return { ...resolvedSchema, ...siblingProps } as ResolvedSchema;
+      }
+
+      return resolvedSchema;
     }
 
     // Couldn't resolve - return original ref


### PR DESCRIPTION
## Summary

- Fixed `resolveNestedRefs` to preserve sibling properties when resolving `$ref` references
- This ensures server default markers (`x-f5xc-server-default`, `x-f5xc-recommended-value`) are not lost

## Problem

When the schema has properties like:
```json
"endpoint_selection": {
  "$ref": "#/components/schemas/clusterEndpointSelectionPolicy",
  "default": "DISTRIBUTED",
  "x-f5xc-server-default": true
}
```

The previous code discarded `default` and `x-f5xc-server-default` when resolving the `$ref`, causing these values to not be extracted for documentation or validation.

## Solution

Now merges sibling properties with the resolved schema, preserving all metadata:
```typescript
// Merge sibling properties with resolved schema
// Sibling properties (like default, x-f5xc-server-default) take precedence
if (Object.keys(siblingProps).length > 0) {
  return { ...resolvedSchema, ...siblingProps } as ResolvedSchema;
}
```

## Test Plan

- [x] Verified `endpoint_selection` now shows `server=true`
- [x] Verified `loadbalancer_algorithm` now shows `server=true`
- [x] All 2990 tests pass (2 failures are unrelated CLI help text tests)
- [x] TypeScript type check passes
- [x] ESLint passes

## Related

- Upstream issue for additional server default markers: https://github.com/robinmordasiewicz/f5xc-api-enriched/issues/469

🤖 Generated with [Claude Code](https://claude.com/claude-code)