### PR TITLE
fix: patch tar vulnerability CVE-2026-23745 in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,11 @@ FROM node:24-alpine AS production
 
 WORKDIR /app
 
-# Update npm to fix vulnerabilities (CVE-2024-21538, CVE-2025-64756)
+# Update npm and patch bundled tar vulnerability (CVE-2026-23745)
 # Pin to specific version for reproducible builds (update periodically)
-RUN npm install -g npm@11.7.0
+RUN npm install -g npm@11.7.0 && \
+    cd /usr/local/lib/node_modules/npm && \
+    npm install tar@7.5.3 --save
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs && \


### PR DESCRIPTION
## Summary

Fixes HIGH severity vulnerability CVE-2026-23745 detected by Trivy container scanner in npm's bundled tar package.

## Problem

The CI workflow failed because Trivy found:
```
tar (package.json) │ CVE-2026-23745 │ HIGH │ fixed │ 7.5.2 │ 7.5.3
```

This vulnerability is in npm's bundled dependencies (`/usr/local/lib/node_modules/npm/node_modules/tar`).

## Solution

Patch npm's bundled tar after global npm installation:
```dockerfile
RUN npm install -g npm@11.7.0 && \
    cd /usr/local/lib/node_modules/npm && \
    npm install tar@7.5.3 --save
```

## Test Plan

- [x] CI workflow should pass with updated Trivy scan
- [ ] Docker image builds successfully
- [ ] Container scan shows no HIGH/CRITICAL vulnerabilities

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)