### PR TITLE
deps: add missing @eslint/js devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/mcpb": "^2.1.0",
+        "@eslint/js": "^9.39.2",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitest/coverage-v8": "^4.0.16",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   ],
   "devDependencies": {
     "@anthropic-ai/mcpb": "^2.1.0",
+    "@eslint/js": "^9.39.2",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^4.0.16",


### PR DESCRIPTION
## Problem Description

The `@eslint/js` package is imported in `eslint.config.js` but not listed in `package.json` devDependencies,
violating the explicit dependency best practice.

```javascript
import js from "@eslint/js";  // ❌ Not in package.json
```

**Identified by**: Systematic codebase analysis (depcheck)
**Evidence**: Issue #258

## Root Cause

- @eslint/js imported directly in eslint.config.js
- Only available as transitive dependency through eslint@9.39.2
- Works currently but can fail in clean installs or future updates
- Violates explicit dependency principle

## Solution

Added `@eslint/js@^9.39.2` as explicit devDependency:

```json
"devDependencies": {
  "@eslint/js": "^9.39.2",
  ...
}
```

**Version rationale**:
- Matches current eslint@9.39.2
- Uses caret range (^) for patch updates
- Compatible with ESLint v9+ flat config format

## Testing

✅ **All checks pass**:
```bash
$ npm run lint
# ✅ No errors

$ npx eslint --print-config src/index.ts
# ✅ Configuration loads correctly

$ npm ci
# ✅ Clean install works
```

## Impact

✅ **Immediate benefits**:
- Predictable dependency resolution
- Prevents installation failures in clean environments
- Clear dependency tree
- Follows npm best practices

✅ **Risk assessment**: **MINIMAL**
- Version already in use (transitive → explicit)
- No API changes
- No breaking changes
- All tests pass

## Acceptance Criteria

- [x] @eslint/js added to devDependencies
- [x] Version ^9.39.2 matches eslint version
- [x] npm run lint passes
- [x] ESLint configuration loads correctly
- [x] package-lock.json updated
- [x] Pre-commit hooks pass

## References

- Resolves #258
- Related: #254, #255, #256, #257, #259, #260 (dependency audit issues)
- Analysis: `claudedocs/issue-discovery-results.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)