### PR TITLE
fix(ci): sync specs before build in mcpb and docker jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,12 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Download OpenAPI specs from upstream
+        run: npm run sync-specs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update version and build
         run: |
@@ -189,10 +194,15 @@ jobs:
           node-version: "24"
           cache: "npm"
 
-      - name: Install dependencies and update version
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Download OpenAPI specs and update version
         run: |
-          npm ci
+          npm run sync-specs
           node scripts/version.js update
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Summary
- Fix failing release workflow where mcpb and docker jobs fail with "specs/index.json not found"
- The `npm ci` command triggers the `prepare` hook which runs build, but specs haven't been downloaded yet
- Use `--ignore-scripts` flag and explicitly sync specs before building

## Root Cause
The security PR #277 removed specs from git and made them download dynamically. But the release.yml mcpb and docker jobs weren't updated to sync specs before the npm ci prepare hook tries to build.

## Changes
- mcpb job: Use `npm ci --ignore-scripts`, add explicit `sync-specs` step before build
- docker job: Use `npm ci --ignore-scripts`, add explicit `sync-specs` step before version update

## Test Plan
- [ ] CI passes on this PR
- [ ] Manually re-run the failed release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)