### PR TITLE
chore(ci): add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - "README.md"
       - "CONTRIBUTING.md"
       - ".github/workflows/docs.yml"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add workflow_dispatch trigger to release workflow for manual triggering
- This allows re-running the release workflow after fixing CI issues

## Test Plan
- [ ] CI passes
- [ ] Merge will trigger a new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)