### PR TITLE
fix: resolve security workflow and CodeQL prototype pollution issues

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -101,6 +101,8 @@ jobs:
   secret-scan:
     name: Secret Detection
     runs-on: ubuntu-latest
+    # Skip on scheduled runs - we scan on every push/PR anyway
+    if: github.event_name != 'schedule'
 
     steps:
       - name: Checkout
@@ -186,14 +188,14 @@ jobs:
           echo "| Scan | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Dependency Scan | ${{ needs.dependency-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Secret Detection | ${{ needs.secret-scan.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Secret Detection | ${{ needs.secret-scan.result == 'success' && '✅ Passed' || (needs.secret-scan.result == 'skipped' && '⏭️ Skipped' || '❌ Failed') }} |" >> $GITHUB_STEP_SUMMARY
           echo "| License Check | ${{ needs.license-check.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| CodeQL Analysis | ${{ needs.codeql.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
 
       - name: Fail if any security check failed
         if: |
           needs.dependency-scan.result != 'success' ||
-          needs.secret-scan.result != 'success' ||
+          (needs.secret-scan.result != 'success' && needs.secret-scan.result != 'skipped') ||
           needs.license-check.result != 'success' ||
           needs.codeql.result != 'success'
         run: |

--- a/tests/uat/utils/schema-driven-tests.ts
+++ b/tests/uat/utils/schema-driven-tests.ts
@@ -239,37 +239,51 @@ const DANGEROUS_PROPERTIES = new Set(["__proto__", "constructor", "prototype"]);
 
 /**
  * Check if a property name is safe (not a prototype pollution vector)
+ * Returns a sanitized key or throws if unsafe
  */
-function isSafePropertyName(name: string): boolean {
-  return !DANGEROUS_PROPERTIES.has(name);
+function sanitizePropertyName(name: string): string {
+  if (DANGEROUS_PROPERTIES.has(name)) {
+    throw new Error(`Unsafe property name: ${name}`);
+  }
+  // Only allow alphanumeric, underscore, and hyphen
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    throw new Error(`Invalid property name format: ${name}`);
+  }
+  return name;
 }
 
 /**
  * Set a nested value in an object using dot notation
- * Includes safeguards against prototype pollution attacks
+ * Uses Object.defineProperty for safe assignment to prevent prototype pollution
  */
 function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
   const parts = path.split(".");
 
-  // Validate all parts are safe property names
-  for (const part of parts) {
-    if (!isSafePropertyName(part)) {
-      throw new Error(`Unsafe property name in path: ${part}`);
-    }
-  }
+  // Sanitize all parts first (throws on unsafe names)
+  const sanitizedParts = parts.map(sanitizePropertyName);
 
   let current = obj;
 
-  for (let i = 0; i < parts.length - 1; i++) {
-    const part = parts[i];
-    if (!(part in current) || typeof current[part] !== "object") {
-      current[part] = {};
+  for (let i = 0; i < sanitizedParts.length - 1; i++) {
+    const part = sanitizedParts[i];
+    if (!Object.prototype.hasOwnProperty.call(current, part) || typeof current[part] !== "object") {
+      Object.defineProperty(current, part, {
+        value: {},
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
     current = current[part] as Record<string, unknown>;
   }
 
-  const finalKey = parts[parts.length - 1];
-  current[finalKey] = value;
+  const finalKey = sanitizedParts[sanitizedParts.length - 1];
+  Object.defineProperty(current, finalKey, {
+    value: value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix failing scheduled security workflow (TruffleHog)
- Fix CodeQL prototype pollution alert #22

## Changes

### 1. Security Workflow Fix
The TruffleHog secret scan was failing on scheduled runs because:
- It tries to compare `main` to `HEAD` which are identical when no new commits exist
- Error: "BASE and HEAD commits are the same. TruffleHog won't scan anything"

**Solution**: Skip TruffleHog on scheduled runs since secret detection runs on every push/PR anyway.

### 2. CodeQL Prototype Pollution Fix
Alert #22 flagged `current[finalKey] = value` as a potential prototype pollution vector.

**Solution**:
- Use `Object.defineProperty` instead of direct property assignment
- Add stricter property name validation (alphanumeric, underscore, hyphen only)
- Use `Object.prototype.hasOwnProperty.call` for safe property existence checks

## Test Plan
- [x] All 3641 tests passing
- [x] TypeScript compilation successful
- [x] Pre-commit hooks passed
- [ ] CI passes
- [ ] CodeQL alert #22 should be resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)