### PR TITLE
fix: use HTML entities for angle bracket escaping in MDX docs

### DIFF
--- a/docs/tools/observability/other/history.mdx
+++ b/docs/tools/observability/other/history.mdx
@@ -25,7 +25,7 @@ filter specified in the request.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `end_time` | Fetch alerts whose timestamp <= end_time | `-` |
+| `end_time` | Fetch alerts whose timestamp &lt;= end_time | `-` |
 | `filter` | HighDiskUsage\", severity=\"critical\"\}" | `-` |
 | `start_time` | Fetch alerts whose timestamp >= start_time | `-` |
 

--- a/docs/tools/service-mesh/suspicious-user.mdx
+++ b/docs/tools/service-mesh/suspicious-user.mdx
@@ -24,7 +24,7 @@ GET status of suspicious users.
 
 | Parameter | Description | Example |
 |-----------|-------------|--------|
-| `end_time` | Fetch suspicious users during timestamp <= end_time | `-` |
+| `end_time` | Fetch suspicious users during timestamp &lt;= end_time | `-` |
 | `query` | Blogging_app"\}" | `-` |
 | `start_time` | Fetch suspicious users during timestamp >= start_time | `-` |
 | `topn` | The topn parameter | `-` |

--- a/docs/tools/support/tenant-management/support-ticket.mdx
+++ b/docs/tools/support/tenant-management/support-ticket.mdx
@@ -5,7 +5,7 @@ description: List of support tickets created for a child tenant.
 
 Return list of support tickets for a given child tenant
 Note: Direct API access is restricted.
-Client needs to use the /managed_tenant/\<mt_identifier>/ prefix in the URL to
+Client needs to use the /managed_tenant/&lt;mt_identifier>/ prefix in the URL to
 GET the support
 ticket list for child tenant.
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -105,7 +105,7 @@ function escapeJsx(text: string): string {
   return text
     .replace(/\{/g, "\\{")
     .replace(/\}/g, "\\}")
-    .replace(/<([a-zA-Z])/g, "\\<$1");
+    .replace(/</g, "&lt;");
 }
 
 /**


### PR DESCRIPTION
## Summary

- Use `&lt;` HTML entities instead of regex-based escaping to handle all angle bracket patterns (`<=`, `>=`, `<name>`)
- Regenerate affected tool docs

Closes #357

## Test plan

- [ ] Verify Astro docs build succeeds after merge
- [ ] Confirm docs site loads at https://robinmordasiewicz.github.io/f5xc-api-mcp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)