### PR TITLE
feat: add concurrency settings to workflows

### DIFF
--- a/.github/workflows/update-f5xc-auth.yml
+++ b/.github/workflows/update-f5xc-auth.yml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-dependency:
     name: Update f5xc-auth to ${{ github.event.client_payload.version }}


### PR DESCRIPTION
## Summary

Add `concurrency` blocks to repo-specific workflows to prevent duplicate runs and save runner minutes.

Closes #456

## Test plan

- [ ] CI checks pass
- [ ] Workflow runs show concurrency group in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)