### PR TITLE
fix: remove stack traces from MCP error responses

### DIFF
--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -333,7 +333,6 @@ export function withErrorHandling<T extends unknown[], R>(
       if (error instanceof Error) {
         throw new F5XCError(error.message, "UNKNOWN_ERROR", {
           originalError: error.name,
-          stack: error.stack,
         });
       }
       throw new F5XCError(String(error), "UNKNOWN_ERROR");

--- a/tests/unit/error-handling-stack-trace.test.ts
+++ b/tests/unit/error-handling-stack-trace.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Tests verifying stack traces are never exposed in error responses.
+ * Security fix for issue #488.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  F5XCError,
+  withErrorHandling,
+  formatErrorForMcp,
+} from "../../src/utils/error-handling.js";
+
+describe("stack trace suppression (#488)", () => {
+  describe("withErrorHandling", () => {
+    it("should not include stack traces in wrapped error context", async () => {
+      const fn = async () => {
+        throw new Error("something broke");
+      };
+      const wrapped = withErrorHandling(fn);
+
+      try {
+        await wrapped();
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(F5XCError);
+        const ctx = (error as F5XCError).context;
+        expect(ctx).toBeDefined();
+        expect(ctx).not.toHaveProperty("stack");
+        expect(ctx).toHaveProperty("originalError");
+      }
+    });
+
+    it("should not leak stack for TypeError", async () => {
+      const fn = async () => {
+        throw new TypeError("null is not an object");
+      };
+      const wrapped = withErrorHandling(fn);
+
+      try {
+        await wrapped();
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect((error as F5XCError).context).not.toHaveProperty("stack");
+      }
+    });
+
+    it("should not leak stack for RangeError", async () => {
+      const fn = async () => {
+        throw new RangeError("Maximum call stack size exceeded");
+      };
+      const wrapped = withErrorHandling(fn);
+
+      try {
+        await wrapped();
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect((error as F5XCError).context).not.toHaveProperty("stack");
+      }
+    });
+  });
+
+  describe("formatErrorForMcp", () => {
+    it("should not include stack traces in serialized MCP error output", () => {
+      const error = new F5XCError("test error", "TEST", {
+        originalError: "Error",
+      });
+      const result = formatErrorForMcp(error);
+      const text = result.content[0].text;
+
+      expect(text).not.toContain("at ");
+      expect(text).not.toContain(".ts:");
+      expect(text).not.toContain(".js:");
+
+      const parsed = JSON.parse(text);
+      expect(parsed.error.details).not.toHaveProperty("stack");
+    });
+
+    it("should not include stack traces when wrapping a regular Error", () => {
+      const error = new Error("regular error");
+      const result = formatErrorForMcp(error);
+      const text = result.content[0].text;
+
+      // formatErrorForMcp doesn't pass context for regular Errors
+      const parsed = JSON.parse(text);
+      expect(parsed.error.details).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Remove `stack: error.stack` from `withErrorHandling()` error context in `src/utils/error-handling.ts`
- Add dedicated test file verifying stack traces are never exposed in error responses

## Test plan
- [x] New tests in `tests/unit/error-handling-stack-trace.test.ts` verify no stack leakage
- [x] Existing `error-handling.test.ts` tests pass without regressions
- [x] TypeScript type checking passes

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)