### PR TITLE
fix: apply consistent URL-encoding to path parameters

### DIFF
--- a/src/resources/templates.ts
+++ b/src/resources/templates.ts
@@ -294,10 +294,10 @@ export function buildApiPath(
     return null;
   }
 
-  let path = rt.apiPath.replace("{namespace}", namespace);
+  let path = rt.apiPath.replace("{namespace}", encodeURIComponent(namespace));
 
   if (name) {
-    path += `/${name}`;
+    path += `/${encodeURIComponent(name)}`;
   }
 
   return path;

--- a/src/services/quota-api-client.ts
+++ b/src/services/quota-api-client.ts
@@ -30,7 +30,7 @@ export async function fetchQuotaUsage(
     logger.debug(`Fetching quota usage for namespace: ${namespace}`);
 
     // Normalize path - remove /api prefix since baseURL includes it
-    const path = `/web/namespaces/${namespace}/quota/usage`;
+    const path = `/web/namespaces/${encodeURIComponent(namespace)}/quota/usage`;
 
     const response = await httpClient.get<F5XCQuotaUsageResponse>(path);
 
@@ -65,7 +65,7 @@ export async function fetchQuotaLimits(
     logger.debug(`Fetching quota limits for namespace: ${namespace}`);
 
     // Normalize path - remove /api prefix since baseURL includes it
-    const path = `/web/namespaces/${namespace}/quota/limits`;
+    const path = `/web/namespaces/${encodeURIComponent(namespace)}/quota/limits`;
 
     const response = await httpClient.get<F5XCQuotaLimitsResponse>(path);
 

--- a/tests/unit/path-encoding.test.ts
+++ b/tests/unit/path-encoding.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Tests for consistent path parameter encoding.
+ * Security fix for issue #491.
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildApiPath } from "../../src/resources/templates.js";
+
+describe("path parameter encoding (#491)", () => {
+  describe("buildApiPath", () => {
+    it("should encode namespace with special characters", () => {
+      const path = buildApiPath("http_loadbalancer", "my namespace");
+      expect(path).toBe("/api/config/namespaces/my%20namespace/http_loadbalancers");
+    });
+
+    it("should encode namespace with slashes", () => {
+      const path = buildApiPath("http_loadbalancer", "ns/evil");
+      expect(path).toBe("/api/config/namespaces/ns%2Fevil/http_loadbalancers");
+    });
+
+    it("should encode namespace with URL-unsafe characters", () => {
+      const path = buildApiPath("healthcheck", "test&ns=admin");
+      expect(path).toBe("/api/config/namespaces/test%26ns%3Dadmin/healthchecks");
+    });
+
+    it("should not double-encode already safe namespaces", () => {
+      const path = buildApiPath("http_loadbalancer", "default");
+      expect(path).toBe("/api/config/namespaces/default/http_loadbalancers");
+    });
+
+    it("should encode name parameter with special characters", () => {
+      const path = buildApiPath("http_loadbalancer", "default", "my lb/test");
+      expect(path).toBe("/api/config/namespaces/default/http_loadbalancers/my%20lb%2Ftest");
+    });
+
+    it("should encode name parameter with URL-unsafe characters", () => {
+      const path = buildApiPath("origin_pool", "default", "pool&name=evil");
+      expect(path).toBe("/api/config/namespaces/default/origin_pools/pool%26name%3Devil");
+    });
+
+    it("should return null for unknown resource types", () => {
+      const path = buildApiPath("nonexistent", "default");
+      expect(path).toBeNull();
+    });
+
+    it("should handle non-namespaced resources", () => {
+      const path = buildApiPath("namespace", "system");
+      // namespace resource has apiPath: /api/web/namespaces (no {namespace} placeholder)
+      expect(path).toBe("/api/web/namespaces");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `encodeURIComponent()` to namespace and name interpolation in `buildApiPath()` (templates.ts)
- Add `encodeURIComponent()` to namespace interpolation in quota API client paths
- Prevents path traversal via crafted namespace/resource names

## Test plan
- [x] New tests in `tests/unit/path-encoding.test.ts` cover special characters, slashes, ampersands
- [x] TypeScript type checking passes

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)