### PR TITLE
fix: restrict F5XC_TLS_INSECURE to staging environments only

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -155,6 +155,24 @@ export async function createServer(): Promise<F5XCApiServer> {
     }
   }
 
+  // Guard: reject F5XC_TLS_INSECURE for production domains
+  if (process.env.F5XC_TLS_INSECURE === "true" && apiUrl) {
+    const normalizedForCheck = normalizeF5XCUrl(apiUrl);
+    try {
+      const hostname = new URL(normalizedForCheck).hostname.toLowerCase();
+      const isProduction = hostname.endsWith(".console.ves.volterra.io") && !hostname.includes(".staging.");
+      if (isProduction) {
+        logger.warn(
+          "F5XC_TLS_INSECURE=true is not allowed for production domains. Clearing the flag.",
+          { hostname }
+        );
+        delete process.env.F5XC_TLS_INSECURE;
+      }
+    } catch {
+      // URL parse failed — normalizeF5XCUrl already warned
+    }
+  }
+
   const credentialManager = new CredentialManager();
   await credentialManager.initialize();
 

--- a/tests/unit/tls-insecure-guard.test.ts
+++ b/tests/unit/tls-insecure-guard.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Tests for F5XC_TLS_INSECURE production guard.
+ * Security fix for issue #494.
+ *
+ * These tests verify the guard logic directly rather than calling createServer(),
+ * which requires CredentialManager initialization and STDIO transport.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { normalizeF5XCUrl } from "../../src/utils/url-utils.js";
+
+/**
+ * Extracted guard logic for testability — mirrors the logic in createServer().
+ * Returns true if the flag was cleared.
+ */
+function shouldClearTlsInsecure(apiUrl: string | undefined, tlsInsecure: string | undefined): boolean {
+  if (tlsInsecure !== "true" || !apiUrl) {
+    return false;
+  }
+
+  const normalizedForCheck = normalizeF5XCUrl(apiUrl);
+  try {
+    const hostname = new URL(normalizedForCheck).hostname.toLowerCase();
+    const isProduction =
+      hostname.endsWith(".console.ves.volterra.io") && !hostname.includes(".staging.");
+    return isProduction;
+  } catch {
+    return false;
+  }
+}
+
+describe("TLS insecure production guard (#494)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.F5XC_TLS_INSECURE;
+    delete process.env.F5XC_API_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("should clear TLS insecure for production console domains", () => {
+    expect(
+      shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", "true")
+    ).toBe(true);
+  });
+
+  it("should clear TLS insecure for production domains without protocol", () => {
+    expect(
+      shouldClearTlsInsecure("tenant.console.ves.volterra.io", "true")
+    ).toBe(true);
+  });
+
+  it("should allow TLS insecure for staging domains", () => {
+    expect(
+      shouldClearTlsInsecure("https://tenant.staging.volterra.us", "true")
+    ).toBe(false);
+  });
+
+  it("should allow TLS insecure for staging console domains", () => {
+    expect(
+      shouldClearTlsInsecure("https://tenant.staging.console.ves.volterra.io", "true")
+    ).toBe(false);
+  });
+
+  it("should not interfere when F5XC_TLS_INSECURE is not set", () => {
+    expect(
+      shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", undefined)
+    ).toBe(false);
+  });
+
+  it("should not interfere when F5XC_TLS_INSECURE is false", () => {
+    expect(
+      shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", "false")
+    ).toBe(false);
+  });
+
+  it("should not interfere when no API URL is set", () => {
+    expect(shouldClearTlsInsecure(undefined, "true")).toBe(false);
+  });
+
+  it("should handle empty API URL", () => {
+    expect(shouldClearTlsInsecure("", "true")).toBe(false);
+  });
+
+  it("should allow TLS insecure for custom non-volterra domains", () => {
+    expect(
+      shouldClearTlsInsecure("https://internal.example.com", "true")
+    ).toBe(false);
+  });
+
+  it("should allow TLS insecure for localhost", () => {
+    expect(
+      shouldClearTlsInsecure("https://localhost:8443", "true")
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add guard in `createServer()` that detects production domains and clears `F5XC_TLS_INSECURE=true`
- Production domains: `*.console.ves.volterra.io` (excluding staging subdomains)
- Staging domains remain unaffected — TLS insecure mode is still available for dev/staging

## Test plan
- [x] New tests in `tests/unit/tls-insecure-guard.test.ts` cover production, staging, custom domains
- [x] TypeScript type checking passes

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)