### PR TITLE
fix: add domain allowlist to prevent SSRF via tenant URL

### DIFF
--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -31,6 +31,44 @@ export function normalizePath(path: string): string {
 }
 
 /**
+ * Default allowed domain patterns for F5XC API endpoints.
+ * These are the legitimate F5 Distributed Cloud domains.
+ */
+const F5XC_DEFAULT_ALLOWED_DOMAINS = [
+  ".console.ves.volterra.io",
+  ".staging.volterra.us",
+  ".ves.volterra.io",
+];
+
+/**
+ * Check whether a hostname belongs to an allowed F5XC domain.
+ *
+ * Matches against the built-in allowlist plus any additional domains
+ * specified in the F5XC_ALLOWED_DOMAINS environment variable
+ * (comma-separated list of domain suffixes).
+ *
+ * @param hostname - Hostname to validate (e.g. "tenant.console.ves.volterra.io")
+ * @returns true if the hostname matches an allowed domain
+ */
+export function isAllowedF5XCDomain(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+
+  // Build full allowlist: defaults + custom
+  const allowed = [...F5XC_DEFAULT_ALLOWED_DOMAINS];
+  const custom = process.env.F5XC_ALLOWED_DOMAINS;
+  if (custom) {
+    for (const domain of custom.split(",")) {
+      const trimmed = domain.trim();
+      if (trimmed) {
+        allowed.push(trimmed.startsWith(".") ? trimmed : `.${trimmed}`);
+      }
+    }
+  }
+
+  return allowed.some((suffix) => lower.endsWith(suffix));
+}
+
+/**
  * Normalize F5XC tenant URL to consistent format.
  *
  * Handles various input formats:
@@ -74,9 +112,22 @@ export function normalizeF5XCUrl(input: string): string {
   // Validate it's a proper URL
   try {
     const parsed = new URL(url);
+
+    // SSRF protection: validate hostname against allowed F5XC domains
+    if (!isAllowedF5XCDomain(parsed.hostname)) {
+      throw new Error(
+        `Domain "${parsed.hostname}" is not an allowed F5XC domain. ` +
+          `Allowed: ${F5XC_DEFAULT_ALLOWED_DOMAINS.join(", ")}. ` +
+          `Set F5XC_ALLOWED_DOMAINS to add custom domains.`
+      );
+    }
+
     // Reconstruct to ensure consistency
     return `${parsed.protocol}//${parsed.hostname}${parsed.port ? `:${parsed.port}` : ""}`;
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("not an allowed F5XC domain")) {
+      throw error; // Re-throw domain validation errors
+    }
     // If URL parsing fails, return the cleaned input
     logger.warn(`Could not parse URL: ${input}, returning cleaned input`);
     return url;
@@ -137,8 +188,24 @@ export async function verifyF5XCEndpoint(
 ): Promise<UrlVerificationResult> {
   const { timeoutMs = 10000, skipVerification = false } = options;
 
-  const normalizedUrl = normalizeF5XCUrl(url);
-  const tenant = extractTenantFromUrl(normalizedUrl);
+  let normalizedUrl: string;
+  let tenant: string | null;
+  try {
+    normalizedUrl = normalizeF5XCUrl(url);
+    tenant = extractTenantFromUrl(normalizedUrl);
+  } catch (error) {
+    // Domain validation failed (SSRF protection)
+    return {
+      valid: false,
+      normalizedUrl: url,
+      tenant: null,
+      error: error instanceof Error ? error.message : String(error),
+      suggestions: [
+        "Verify the tenant URL is a valid F5XC domain",
+        "Set F5XC_ALLOWED_DOMAINS to add custom domain suffixes",
+      ],
+    };
+  }
 
   // If verification is skipped, just return the normalized URL
   if (skipVerification) {

--- a/tests/unit/url-utils-ssrf.test.ts
+++ b/tests/unit/url-utils-ssrf.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+/**
+ * Tests for SSRF domain allowlist protection.
+ * Security fix for issue #487.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isAllowedF5XCDomain, normalizeF5XCUrl } from "../../src/utils/url-utils.js";
+
+describe("SSRF domain allowlist (#487)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.F5XC_ALLOWED_DOMAINS;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe("isAllowedF5XCDomain", () => {
+    it("should allow production console domains", () => {
+      expect(isAllowedF5XCDomain("tenant.console.ves.volterra.io")).toBe(true);
+    });
+
+    it("should allow staging domains", () => {
+      expect(isAllowedF5XCDomain("tenant.staging.volterra.us")).toBe(true);
+    });
+
+    it("should allow ves.volterra.io subdomains", () => {
+      expect(isAllowedF5XCDomain("anything.ves.volterra.io")).toBe(true);
+    });
+
+    it("should reject arbitrary domains", () => {
+      expect(isAllowedF5XCDomain("evil.com")).toBe(false);
+    });
+
+    it("should reject internal network addresses", () => {
+      expect(isAllowedF5XCDomain("localhost")).toBe(false);
+      expect(isAllowedF5XCDomain("192.168.1.1")).toBe(false);
+      expect(isAllowedF5XCDomain("10.0.0.1")).toBe(false);
+    });
+
+    it("should reject domains that contain volterra but are not subdomains", () => {
+      expect(isAllowedF5XCDomain("volterra.io.evil.com")).toBe(false);
+      expect(isAllowedF5XCDomain("fakevolterra.io")).toBe(false);
+    });
+
+    it("should be case-insensitive", () => {
+      expect(isAllowedF5XCDomain("Tenant.Console.Ves.Volterra.IO")).toBe(true);
+    });
+
+    it("should allow custom domains from F5XC_ALLOWED_DOMAINS", () => {
+      process.env.F5XC_ALLOWED_DOMAINS = "internal.corp.com,dev.example.io";
+      expect(isAllowedF5XCDomain("api.internal.corp.com")).toBe(true);
+      expect(isAllowedF5XCDomain("test.dev.example.io")).toBe(true);
+    });
+
+    it("should handle leading dots in F5XC_ALLOWED_DOMAINS", () => {
+      process.env.F5XC_ALLOWED_DOMAINS = ".custom.domain.com";
+      expect(isAllowedF5XCDomain("api.custom.domain.com")).toBe(true);
+    });
+
+    it("should handle whitespace in F5XC_ALLOWED_DOMAINS", () => {
+      process.env.F5XC_ALLOWED_DOMAINS = " custom.com , other.com ";
+      expect(isAllowedF5XCDomain("api.custom.com")).toBe(true);
+      expect(isAllowedF5XCDomain("api.other.com")).toBe(true);
+    });
+  });
+
+  describe("normalizeF5XCUrl SSRF protection", () => {
+    it("should accept valid F5XC production URLs", () => {
+      expect(normalizeF5XCUrl("tenant.console.ves.volterra.io")).toBe(
+        "https://tenant.console.ves.volterra.io"
+      );
+    });
+
+    it("should accept valid F5XC staging URLs", () => {
+      expect(normalizeF5XCUrl("tenant.staging.volterra.us")).toBe(
+        "https://tenant.staging.volterra.us"
+      );
+    });
+
+    it("should throw for non-F5XC domains", () => {
+      expect(() => normalizeF5XCUrl("https://evil.com")).toThrow("not an allowed F5XC domain");
+    });
+
+    it("should throw for internal network addresses", () => {
+      expect(() => normalizeF5XCUrl("http://localhost:8080")).toThrow(
+        "not an allowed F5XC domain"
+      );
+    });
+
+    it("should throw for metadata service URLs (cloud SSRF)", () => {
+      expect(() => normalizeF5XCUrl("http://169.254.169.254")).toThrow(
+        "not an allowed F5XC domain"
+      );
+    });
+
+    it("should accept custom domains when configured", () => {
+      process.env.F5XC_ALLOWED_DOMAINS = "custom.internal.com";
+      expect(normalizeF5XCUrl("api.custom.internal.com")).toBe(
+        "https://api.custom.internal.com"
+      );
+    });
+
+    it("should still return empty for empty input", () => {
+      expect(normalizeF5XCUrl("")).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isAllowedF5XCDomain()` function that validates hostnames against F5XC domain allowlist
- Integrate domain validation into `normalizeF5XCUrl()` — rejects non-F5XC domains with descriptive error
- Default allowed: `*.console.ves.volterra.io`, `*.staging.volterra.us`, `*.ves.volterra.io`
- Custom domains via `F5XC_ALLOWED_DOMAINS` env var (comma-separated)
- `verifyF5XCEndpoint()` gracefully handles domain rejection (returns invalid result)

## Test plan
- [x] New tests in `tests/unit/url-utils-ssrf.test.ts` cover allowlist, rejection, custom domains
- [x] Existing `url-utils.test.ts` tests pass without regressions (121 total)
- [x] TypeScript type checking passes

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)