### PR TITLE
fix: align TLS guard test with SSRF allowlist

### DIFF
--- a/tests/unit/tls-insecure-guard.test.ts
+++ b/tests/unit/tls-insecure-guard.test.ts
@@ -15,12 +15,21 @@ import { normalizeF5XCUrl } from "../../src/utils/url-utils.js";
  * Extracted guard logic for testability — mirrors the logic in createServer().
  * Returns true if the flag was cleared.
  */
-function shouldClearTlsInsecure(apiUrl: string | undefined, tlsInsecure: string | undefined): boolean {
+function shouldClearTlsInsecure(
+  apiUrl: string | undefined,
+  tlsInsecure: string | undefined
+): boolean {
   if (tlsInsecure !== "true" || !apiUrl) {
     return false;
   }
 
-  const normalizedForCheck = normalizeF5XCUrl(apiUrl);
+  let normalizedForCheck: string;
+  try {
+    normalizedForCheck = normalizeF5XCUrl(apiUrl);
+  } catch {
+    // SSRF domain validation rejected the URL — not a production domain
+    return false;
+  }
   try {
     const hostname = new URL(normalizedForCheck).hostname.toLowerCase();
     const isProduction =
@@ -44,39 +53,29 @@ describe("TLS insecure production guard (#494)", () => {
   });
 
   it("should clear TLS insecure for production console domains", () => {
-    expect(
-      shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", "true")
-    ).toBe(true);
+    expect(shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", "true")).toBe(true);
   });
 
   it("should clear TLS insecure for production domains without protocol", () => {
-    expect(
-      shouldClearTlsInsecure("tenant.console.ves.volterra.io", "true")
-    ).toBe(true);
+    expect(shouldClearTlsInsecure("tenant.console.ves.volterra.io", "true")).toBe(true);
   });
 
   it("should allow TLS insecure for staging domains", () => {
-    expect(
-      shouldClearTlsInsecure("https://tenant.staging.volterra.us", "true")
-    ).toBe(false);
+    expect(shouldClearTlsInsecure("https://tenant.staging.volterra.us", "true")).toBe(false);
   });
 
   it("should allow TLS insecure for staging console domains", () => {
-    expect(
-      shouldClearTlsInsecure("https://tenant.staging.console.ves.volterra.io", "true")
-    ).toBe(false);
+    expect(shouldClearTlsInsecure("https://tenant.staging.console.ves.volterra.io", "true")).toBe(
+      false
+    );
   });
 
   it("should not interfere when F5XC_TLS_INSECURE is not set", () => {
-    expect(
-      shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", undefined)
-    ).toBe(false);
+    expect(shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", undefined)).toBe(false);
   });
 
   it("should not interfere when F5XC_TLS_INSECURE is false", () => {
-    expect(
-      shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", "false")
-    ).toBe(false);
+    expect(shouldClearTlsInsecure("https://tenant.console.ves.volterra.io", "false")).toBe(false);
   });
 
   it("should not interfere when no API URL is set", () => {
@@ -88,14 +87,10 @@ describe("TLS insecure production guard (#494)", () => {
   });
 
   it("should allow TLS insecure for custom non-volterra domains", () => {
-    expect(
-      shouldClearTlsInsecure("https://internal.example.com", "true")
-    ).toBe(false);
+    expect(shouldClearTlsInsecure("https://internal.example.com", "true")).toBe(false);
   });
 
   it("should allow TLS insecure for localhost", () => {
-    expect(
-      shouldClearTlsInsecure("https://localhost:8443", "true")
-    ).toBe(false);
+    expect(shouldClearTlsInsecure("https://localhost:8443", "true")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Fix test helper `shouldClearTlsInsecure()` to catch SSRF domain validation errors from `normalizeF5XCUrl()`
- Matches the try/catch pattern used in `createServer()` in `src/server.ts`
- Resolves 2 failing tests: "custom non-volterra domains" and "localhost"

## Test plan
- [x] All 10 TLS guard tests pass (20 with typecheck)
- [x] `npx prettier --check` passes

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)