### PR TITLE
feat: add super-linter CI workflow for production readiness

### DIFF
--- a/.github/linters/.editorconfig-checker.json
+++ b/.github/linters/.editorconfig-checker.json
@@ -1,0 +1,12 @@
+{
+  "exclude": [
+    "\\.git/",
+    "node_modules/",
+    "dist/",
+    "coverage/",
+    "specs/",
+    "\\.png$",
+    "\\.ico$",
+    "package-lock\\.json$"
+  ]
+}

--- a/.github/linters/.hadolint.yaml
+++ b/.github/linters/.hadolint.yaml
@@ -1,0 +1,6 @@
+# Hadolint configuration for Dockerfile linting
+# https://github.com/hadolint/hadolint
+
+ignored:
+  # Multiple consecutive COPY --from is acceptable in multi-stage builds
+  - DL3059

--- a/.github/linters/.markdown-lint.json
+++ b/.github/linters/.markdown-lint.json
@@ -1,0 +1,22 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 120,
+    "heading_line_length": 120,
+    "code_block_line_length": 200,
+    "tables": false
+  },
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD028": false,
+  "MD033": {
+    "allowed_elements": ["div", "br", "sup", "sub", "details", "summary"]
+  },
+  "MD040": true,
+  "MD046": false,
+  "MD048": {
+    "style": "backtick"
+  },
+  "MD060": false
+}

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,23 @@
+# yamllint configuration — mirrors root .yamllint.yml
+# Super-linter expects this filename in .github/linters/
+
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start: disable
+  truthy:
+    allowed-values: ["true", "false", "yes", "no", "on", "off"]
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    spaces: 2
+    indent-sequences: true
+
+ignore:
+  - node_modules/
+  - dist/
+  - specs/
+  - coverage/

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,49 @@
+name: Super-Linter
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  super-linter:
+    name: Lint (Super-Linter)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      statuses: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Super-Linter
+        uses: super-linter/super-linter/slim@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: true
+
+          # Opt-in: only enable linters that add CI value
+          # ESLint/Prettier/TypeScript are handled by ci.yml with project deps
+          VALIDATE_BASH: true
+          VALIDATE_DOCKERFILE_HADOLINT: true
+          VALIDATE_EDITORCONFIG: true
+          VALIDATE_GITHUB_ACTIONS: true
+          VALIDATE_GITLEAKS: true
+          VALIDATE_JSON: true
+          VALIDATE_MARKDOWN: true
+          VALIDATE_YAML: true
+
+          # Config file overrides
+          MARKDOWN_CONFIG_FILE: .markdown-lint.json
+
+          # Exclude generated/downloaded content and MDX files
+          FILTER_REGEX_EXCLUDE: .*\.mdx$|^specs/.*|^coverage/.*|^dist/.*


### PR DESCRIPTION
## Summary

- Add GitHub Super-Linter workflow with opt-in linters for comprehensive CI coverage
- Enable Hadolint (Dockerfile), editorconfig-checker, and jsonlint as **new** CI gates
- Promote pre-commit-only checks (shellcheck, actionlint, yamllint, markdownlint, gitleaks) to CI-enforced gates
- ESLint/Prettier/TypeScript deliberately excluded — already handled by `ci.yml` with project deps

## Test plan

- [ ] Super-linter workflow runs and all enabled linters pass
- [ ] Existing `ci.yml` pipeline continues to pass without interference
- [ ] Hadolint validates the Dockerfile without errors
- [ ] editorconfig-checker enforces `.editorconfig` rules
- [ ] MDX files and `specs/` directory are properly excluded via `FILTER_REGEX_EXCLUDE`

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)