### PR TITLE
feat(specs): Update OpenAPI specs to v2.1.86

### DIFF
--- a/src/tools/generated/dependency-graph.json
+++ b/src/tools/generated/dependency-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-05-05T07:01:24.479461+00:00",
+  "generatedAt": "2026-05-06T07:17:19.966847+00:00",
   "totalResources": 819,
   "dependencies": {
     "admin_console_and_ui/static-component": {

--- a/tests/fixtures/generated.ts
+++ b/tests/fixtures/generated.ts
@@ -5,7 +5,7 @@
  * These fixtures are dynamically generated from the current OpenAPI specs
  * to ensure tests always use real values and don't hardcode spec content.
  *
- * Generated at: 2026-05-06T07:00:27.155Z
+ * Generated at: 2026-05-06T07:19:45.524Z
  * Total tools: 1586
  * Total domains: 38
  */


### PR DESCRIPTION
## OpenAPI Specification Update

**New Version**: v2.1.86

### Source
- Repository: [robinmordasiewicz/f5xc-api-enriched](https://github.com/robinmordasiewicz/f5xc-api-enriched)

### Statistics
- **Total Tools**: 1586
- **Total Domains**: 38

### Changes
- Downloaded latest enriched specs from upstream (dynamically, not stored in git)
- Regenerated MCP tools from new specs
- Regenerated dynamic test fixtures
- All tests passing

### Validation
- [x] TypeScript compilation
- [x] Unit tests passing
- [x] Lint checks passing
- [x] Build successful

---
🤖 Generated automatically by OpenAPI Sync workflow