### PR TITLE
feat(specs): Update OpenAPI specs to v2.1.98

### DIFF
--- a/tests/fixtures/generated.ts
+++ b/tests/fixtures/generated.ts
@@ -5,7 +5,7 @@
  * These fixtures are dynamically generated from the current OpenAPI specs
  * to ensure tests always use real values and don't hardcode spec content.
  *
- * Generated at: 2026-05-18T18:41:36.788Z
+ * Generated at: 2026-05-19T00:52:49.325Z
  * Total tools: 1586
  * Total domains: 38
  */


### PR DESCRIPTION
## OpenAPI Specification Update

**New Version**: v2.1.98

### Source
- Repository: [robinmordasiewicz/f5xc-api-enriched](https://github.com/robinmordasiewicz/f5xc-api-enriched)

### Statistics
- **Total Tools**: 1586
- **Total Domains**: 38

### Changes
- Downloaded latest enriched specs from upstream (dynamically, not stored in git)
- Regenerated MCP tools from new specs
- Regenerated dynamic test fixtures
- All tests passing

### Validation
- [x] TypeScript compilation
- [x] Unit tests passing
- [x] Lint checks passing
- [x] Build successful

---
🤖 Generated automatically by OpenAPI Sync workflow